### PR TITLE
Add note about activating the debug mode

### DIFF
--- a/docs/Maintenance/Maintenance.md
+++ b/docs/Maintenance/Maintenance.md
@@ -21,6 +21,8 @@ Commands
 cake Setup.MaintenanceMode activate
 // Optionally whitelist your IP:
 cake Setup.MaintenanceMode whitelist YOURIP
+// Optionally whitelist your IP and activate the debug mode for when you access the application:
+cake Setup.MaintenanceMode whitelist YOURIP --debug
 // ... Do your work ...
 cake Setup.MaintenanceMode deactivate
 ```


### PR DESCRIPTION
I was testing your plugin locally and rand into a situation where the debug toolbar was not shown but an error message instead even though I set debug to true. Took me quite some time untill I found out I can (and should) manually activate the debug mode for my IP trhough the CLI.

I'm not sure if this is really the best solution. Either it needs more documentation or it should respect the current setting for the debug mode.