### PR TITLE
tests: add missing AppController fixture

### DIFF
--- a/tests/test_app/src/Controller/AppController.php
+++ b/tests/test_app/src/Controller/AppController.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Controller;
+
+class AppController
+{
+
+}


### PR DESCRIPTION
Based on applying Rector to this package: https://github.com/rectorphp/rector/issues/619#issuecomment-421804101

```
git clone git@github.com:TomasVotruba/cakephp-setup.git
cd cakephp-setup
composer require rector/rector --dev
vendor/bin/rector process src --level cakephp36
```

make OK pass

![done](https://user-images.githubusercontent.com/924196/45599406-53d94080-b9eb-11e8-8cf5-609cf32a6b98.gif)

Related warning is not related to upgrade. It's due to wierd assumption on file laod. The deprecation should be done in its constructor.