### PR TITLE
Add TypeMap debug info.

### DIFF
--- a/src/Controller/Admin/BackendController.php
+++ b/src/Controller/Admin/BackendController.php
@@ -6,10 +6,12 @@ use App\Controller\AppController;
 use Cake\Cache\Cache;
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\I18n\DateTime;
 use Cake\ORM\TableRegistry;
 use PDO;
 use Setup\Utility\Config;
+use Setup\Utility\OrmTypes;
 
 class BackendController extends AppController {
 
@@ -124,6 +126,20 @@ class BackendController extends AppController {
 		$localConfig = Config::getLocal();
 
 		$this->set(compact('envVars', 'localConfig'));
+	}
+
+	/**
+	 * @return \Cake\Http\Response|null|void
+	 */
+	public function typeMap() {
+		$plugins = Plugin::loaded();
+		if ($this->request->getQuery('all')) {
+			$plugins = array_keys((array)Configure::read('plugins'));
+		}
+		$map = OrmTypes::getMap();
+		$classes = OrmTypes::getClasses($plugins, $map);
+
+		$this->set(compact('plugins', 'classes', 'map'));
 	}
 
 }

--- a/src/Utility/ClassFinder.php
+++ b/src/Utility/ClassFinder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Setup\Utility;
+
+use Cake\Core\App;
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Shim\Filesystem\Folder;
+
+class ClassFinder {
+
+	/**
+	 * @param string $string
+	 * @param array<string>|null $plugins
+	 *
+	 * @return array<string, array<string>>
+	 */
+	public static function get(string $string, ?array $plugins): array {
+		$appPaths = App::classPath($string);
+		$result = [];
+		$classes = static::getClasses($appPaths);
+		if ($classes) {
+			$appNamespace = (string)Configure::readOrFail('App.namespace');
+			$result[strtoupper($appNamespace)] = $classes;
+		}
+
+		if ($plugins === null) {
+			$plugins = Plugin::loaded();
+		}
+		foreach ($plugins as $plugin) {
+			$pluginPaths = App::classPath($string, $plugin);
+			$classes = static::getClasses($pluginPaths);
+			if ($classes) {
+				$result[$plugin] = $classes;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param array<string> $folders
+	 *
+	 * @return array<string>
+	 */
+	public static function getClasses(array $folders): array {
+		$names = [];
+		foreach ($folders as $folder) {
+			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
+
+			foreach ($folderContent[1] as $file) {
+				$name = pathinfo($file, PATHINFO_FILENAME);
+				$names[] = $name;
+			}
+
+			foreach ($folderContent[0] as $subFolder) {
+				$folderContent = (new Folder($folder . $subFolder))->read(Folder::SORT_NAME, true);
+
+				foreach ($folderContent[1] as $file) {
+					$name = pathinfo($file, PATHINFO_FILENAME);
+					$names[] = $subFolder . '/' . $name;
+				}
+			}
+		}
+
+		return $names;
+	}
+
+}

--- a/src/Utility/OrmTypes.php
+++ b/src/Utility/OrmTypes.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Setup\Utility;
+
+use Cake\Core\Configure;
+use Cake\Database\TypeFactory;
+use Cake\Utility\Hash;
+use RuntimeException;
+
+class OrmTypes {
+
+	/**
+	 * @var string
+	 */
+	public const NAMESPACE = 'Database/Type';
+
+	/**
+	 * @var string
+	 */
+	public const SUFFIX = 'Type';
+
+	/**
+	 * @param array $plugins
+	 * @param array $map Map of already mapped types to exclude.
+	 *
+	 * @return array
+	 */
+	public static function getClasses(array $plugins = [], array $map = []): array {
+		$exclude = [];
+		if ($map) {
+			$exclude = Hash::extract($map, '{s}.class');
+		}
+
+		$allClasses = ClassFinder::get('Database/Type', $plugins);
+		foreach ($allClasses as $namespace => $classes) {
+			$result = [];
+			foreach ($classes as $class) {
+				$namespacePrefix = str_replace('/', '\\', static::NAMESPACE);
+				$fullClass = $namespacePrefix . '\\' . $class;
+				if (strtoupper($namespace) !== strtoupper(Configure::readOrFail('App.namespace'))) {
+					$fullClass = str_replace('/', '\\', $namespace) . '\\' . $fullClass;
+				}
+				$name = substr($class, 0, -strlen(static::SUFFIX));
+
+				if ($exclude && in_array($fullClass, $exclude, true)) {
+					continue;
+				}
+
+				$result[$name] = $fullClass;
+			}
+
+			$allClasses[$namespace] = $result;
+			if (!$allClasses[$namespace]) {
+				unset($allClasses[$namespace]);
+			}
+		}
+
+		return $allClasses;
+	}
+
+	/**
+	 * @return array<string, array<string, string>>
+	 */
+	public static function getMap(): array {
+		/** @var array<string, string> $map */
+		$map = TypeFactory::getMap();
+
+		$result = [];
+		foreach ($map as $type => $class) {
+			$name = static::name($class);
+
+			$result[$type] = [
+				'name' => $name,
+				'class' => $class,
+			];
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param string $class
+	 *
+	 * @return string
+	 */
+	protected static function name(string $class): string {
+		$namespace = str_replace('/', '\\', static::NAMESPACE);
+		preg_match('#^(.+)\\\\' . preg_quote($namespace) . '\\\\(.+)' . preg_quote(static::SUFFIX) . '#', $class, $matches);
+		if (!$matches) {
+			throw new RuntimeException('Invalid type class: ' . $class);
+		}
+
+		if ($matches[1] === 'Cake' || $matches[1] === Configure::readOrFail('App.namespace')) {
+			return $matches[2];
+		}
+
+		return $matches[1] . '.' . $matches[2];
+	}
+
+}

--- a/templates/Admin/Backend/type_map.php
+++ b/templates/Admin/Backend/type_map.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<string> $plugins
+ * @var array $classes
+ * @var array<string, array<string, string>> $map
+ */
+?>
+
+<h1>TypeMap overview</h1>
+
+<div class="row">
+	<div class="col-md-8">
+		<h2>Mapped types</h2>
+
+		<table class="table">
+			<tr>
+				<th>Type</th>
+				<th>Name</th>
+				<th>Class</th>
+            </tr>
+			</tr>
+			<?php
+			foreach ($map as $type => $info) {
+				?>
+				<tr>
+					<td>
+						<?php echo h($type); ?>
+					</td>
+					<td>
+						<span><?php echo h($info['name']); ?></span>
+					</td>
+					<td>
+						<small><code><?php echo h($info['class']); ?></code></small>
+					</td>
+				</tr>
+				<?php
+			}
+			?>
+		</table>
+	</div>
+	<div class="col-md-4">
+		<h2>Available classes</h2>
+		<p>The following <?php echo count($plugins) ?> <?php echo ($this->request->getQuery('all') ? '' : 'loaded'); ?> plugins have been searched:
+		<br>
+			<small><?php echo implode(', ', $plugins)?></small>
+		</p>
+
+		<p>The following not (yet) used type classes have been found:</p>
+		<ul>
+		<?php foreach ($classes as $namespace => $classNames) { ?>
+		<li>
+			<?php echo h($namespace); ?>
+			<ul>
+				<?php foreach ($classNames as $name => $className) { ?>
+				<li>
+					<?php echo h($name); ?>
+					<div>
+						<small><code><?php echo h($className); ?></code></small>
+					</div>
+				</li>
+				<?php } ?>
+			</ul>
+		</li>
+		<?php } ?>
+		</ul>
+
+		<p><?php echo ($this->request->getQuery('all') ? $this->Html->link('Check loaded plugins only', ['?' => []]) : $this->Html->link('Check all available plugins', ['?' => ['all' => true]])); ?></p>
+	</div>
+</div>

--- a/templates/Admin/Setup/index.php
+++ b/templates/Admin/Setup/index.php
@@ -7,11 +7,13 @@
 
 <h1>Setup Backend Tools</h1>
 
-<ul>
-	<li><?php echo $this->Html->link('PHP Info', ['controller' => 'Backend', 'action' => 'phpinfo']);?></li>
-	<li><?php echo $this->Html->link('Session Info', ['controller' => 'Backend', 'action' => 'session']);?></li>
-	<li><?php echo $this->Html->link('Cache Info and Testing', ['controller' => 'Backend', 'action' => 'cache']);?></li>
-	<li><?php echo $this->Html->link('Database Info', ['controller' => 'Backend', 'action' => 'database']);?></li>
-</ul>
+
+	<ul>
+		<li><?php echo $this->Html->link('PHP Info', ['controller' => 'Backend', 'action' => 'phpinfo']);?></li>
+		<li><?php echo $this->Html->link('Session Info', ['controller' => 'Backend', 'action' => 'session']);?></li>
+		<li><?php echo $this->Html->link('Cache Info and Testing', ['controller' => 'Backend', 'action' => 'cache']);?></li>
+		<li><?php echo $this->Html->link('Database Info', ['controller' => 'Backend', 'action' => 'database']);?></li>
+		<li><?php echo $this->Html->link('ORM Type Map', ['controller' => 'Backend', 'action' => 'typeMap']); ?></li>
+	</ul>
 
 </div>

--- a/tests/TestCase/Controller/Admin/BackendControllerTest.php
+++ b/tests/TestCase/Controller/Admin/BackendControllerTest.php
@@ -92,4 +92,17 @@ class BackendControllerTest extends TestCase {
 		$this->assertResponseCode(200);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testTypeMap() {
+		$this->disableErrorHandlerMiddleware();
+
+		$this->session(['Auth' => ['User' => ['id' => 1]]]);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Setup', 'controller' => 'Backend', 'action' => 'typeMap']);
+
+		$this->assertResponseCode(200);
+	}
+
 }


### PR DESCRIPTION
Do people find this backed info useful?

    /admin/setup/backend/type-map

I so far did. Helped me to find out which classes are currently mapped, and what types/classes are available.

![setup_plugin_type_map](https://github.com/dereuromark/cakephp-setup/assets/39854/110652c4-78be-4e05-a6f0-18622499fd00)
