### PR TITLE
Add missing command description for mail_check

### DIFF
--- a/src/Command/MailCheckCommand.php
+++ b/src/Command/MailCheckCommand.php
@@ -58,6 +58,7 @@ TXT;
 	 */
 	public function getOptionParser(): ConsoleOptionParser {
 		$parser = parent::getOptionParser();
+		$parser->setDescription('Send a test email from CLI to verify mail config.');
 
 		return $parser;
 	}


### PR DESCRIPTION
## Summary
- Adds missing description for the `mail_check` command so it appears in the CLI command listing.