### PR TITLE
Add pathWhitelist option to MaintenanceMiddleware

### DIFF
--- a/docs/Maintenance/Maintenance.md
+++ b/docs/Maintenance/Maintenance.md
@@ -58,9 +58,23 @@ Configs:
 - 'templateLayout' => false,
 - 'templateFileName' => 'maintenance',
 - 'templateExtension' => '.php',
-- 'contentType' => 'text/html'
+- 'contentType' => 'text/html',
+- 'pathWhitelist' => []
 
 Those can be used to adjust the content of the maintenance mode page.
+
+### Path Whitelist
+You can exclude certain paths from maintenance mode using the `pathWhitelist` option.
+This is useful for healthcheck endpoints that need to remain accessible during maintenance
+to prevent load balancers from cycling out containers:
+
+```php
+$middlewareQueue->add(new MaintenanceMiddleware([
+    'pathWhitelist' => ['/setup/healthcheck', '/health'],
+]));
+```
+
+Paths are matched exactly or as prefixes, so `/health` also matches `/health/detailed`.
 
 
 ## Maintenance Component

--- a/docs/Maintenance/Maintenance.md
+++ b/docs/Maintenance/Maintenance.md
@@ -66,7 +66,7 @@ Those can be used to adjust the content of the maintenance mode page.
 ### Path Whitelist
 You can exclude certain paths from maintenance mode using the `pathWhitelist` option.
 This is useful for healthcheck endpoints that need to remain accessible during maintenance
-to prevent load balancers from cycling out containers:
+to prevent load balancers from cycling out servers:
 
 ```php
 $middlewareQueue->add(new MaintenanceMiddleware([

--- a/src/Middleware/MaintenanceMiddleware.php
+++ b/src/Middleware/MaintenanceMiddleware.php
@@ -19,7 +19,7 @@ class MaintenanceMiddleware implements MiddlewareInterface {
 	use InstanceConfigTrait;
 
 	/**
-	 * @var array
+	 * @var array<string, mixed>
 	 */
 	protected array $_defaultConfig = [
 		'className' => View::class,
@@ -29,6 +29,7 @@ class MaintenanceMiddleware implements MiddlewareInterface {
 		'templateFileName' => 'maintenance',
 		'templateExtension' => '.php',
 		'contentType' => 'text/html',
+		'pathWhitelist' => [],
 	];
 
 	/**
@@ -45,10 +46,14 @@ class MaintenanceMiddleware implements MiddlewareInterface {
 	 * @return \Psr\Http\Message\ResponseInterface
 	 */
 	public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface {
+		$response = $handler->handle($request);
+
+		if ($this->isPathWhitelisted($request->getUri()->getPath())) {
+			return $response;
+		}
+
 		$ip = $request->clientIp();
 		$maintenance = new Maintenance();
-
-		$response = $handler->handle($request);
 		if (!$maintenance->isMaintenanceMode($ip)) {
 			return $response;
 		}
@@ -56,6 +61,24 @@ class MaintenanceMiddleware implements MiddlewareInterface {
 		$response = $this->build($response);
 
 		return $response;
+	}
+
+	/**
+	 * Check if the given path is whitelisted from maintenance mode.
+	 *
+	 * @param string $path The request path to check.
+	 * @return bool
+	 */
+	protected function isPathWhitelisted(string $path): bool {
+		/** @var array<string> $whitelist */
+		$whitelist = $this->getConfig('pathWhitelist');
+		foreach ($whitelist as $pattern) {
+			if ($path === $pattern || str_starts_with($path, rtrim($pattern, '/') . '/')) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/TestCase/Middleware/MaintenanceMiddlewareTest.php
+++ b/tests/TestCase/Middleware/MaintenanceMiddlewareTest.php
@@ -50,4 +50,42 @@ class MaintenanceMiddlewareTest extends TestCase {
 		$this->assertStringContainsString('<h1>We are working right now</h1>', $body);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testIsPathWhitelistedExactMatch(): void {
+		$middleware = new MaintenanceMiddleware([
+			'pathWhitelist' => ['/health', '/setup/healthcheck'],
+		]);
+
+		$this->assertTrue($this->invokeMethod($middleware, 'isPathWhitelisted', ['/health']));
+		$this->assertTrue($this->invokeMethod($middleware, 'isPathWhitelisted', ['/setup/healthcheck']));
+		$this->assertFalse($this->invokeMethod($middleware, 'isPathWhitelisted', ['/other']));
+		$this->assertFalse($this->invokeMethod($middleware, 'isPathWhitelisted', ['/']));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIsPathWhitelistedPrefixMatch(): void {
+		$middleware = new MaintenanceMiddleware([
+			'pathWhitelist' => ['/api/health'],
+		]);
+
+		$this->assertTrue($this->invokeMethod($middleware, 'isPathWhitelisted', ['/api/health']));
+		$this->assertTrue($this->invokeMethod($middleware, 'isPathWhitelisted', ['/api/health/detailed']));
+		$this->assertFalse($this->invokeMethod($middleware, 'isPathWhitelisted', ['/api/healthcheck']));
+		$this->assertFalse($this->invokeMethod($middleware, 'isPathWhitelisted', ['/api']));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIsPathWhitelistedEmptyList(): void {
+		$middleware = new MaintenanceMiddleware();
+
+		$this->assertFalse($this->invokeMethod($middleware, 'isPathWhitelisted', ['/health']));
+		$this->assertFalse($this->invokeMethod($middleware, 'isPathWhitelisted', ['/']));
+	}
+
 }


### PR DESCRIPTION
## Summary

- Adds `pathWhitelist` configuration option to `MaintenanceMiddleware`
- Allows excluding specific paths (e.g., healthcheck endpoints) from maintenance mode
- Prevents load balancers from cycling out containers that are under maintenance but otherwise healthy

## Usage

```php
new MaintenanceMiddleware([
    'pathWhitelist' => ['/health', '/setup/healthcheck'],
]);
```

Paths are matched exactly or as prefixes, so `/health` also matches `/health/detailed`.