### PR TITLE
Type $args and $io properties in commands for 5.next compatibility

### DIFF
--- a/src/Command/DbBackupCreateCommand.php
+++ b/src/Command/DbBackupCreateCommand.php
@@ -25,15 +25,9 @@ class DbBackupCreateCommand extends Command {
 	use DbToolsTrait;
 	use DbBackupTrait;
 
-	/**
-	 * @var \Cake\Console\Arguments
-	 */
-	protected $args;
+	protected Arguments $args;
 
-	/**
-	 * @var \Cake\Console\ConsoleIo
-	 */
-	protected $io;
+	protected ConsoleIo $io;
 
 	/**
 	 * @return string

--- a/src/Command/DbBackupRestoreCommand.php
+++ b/src/Command/DbBackupRestoreCommand.php
@@ -23,15 +23,9 @@ class DbBackupRestoreCommand extends Command {
 	use DbToolsTrait;
 	use DbBackupTrait;
 
-	/**
-	 * @var \Cake\Console\Arguments
-	 */
-	protected $args;
+	protected Arguments $args;
 
-	/**
-	 * @var \Cake\Console\ConsoleIo
-	 */
-	protected $io;
+	protected ConsoleIo $io;
 
 	/**
 	 * @return string

--- a/src/Command/DbInitCommand.php
+++ b/src/Command/DbInitCommand.php
@@ -19,15 +19,9 @@ class DbInitCommand extends Command {
 
 	use DbToolsTrait;
 
-	/**
-	 * @var \Cake\Console\Arguments
-	 */
-	protected $args;
+	protected Arguments $args;
 
-	/**
-	 * @var \Cake\Console\ConsoleIo
-	 */
-	protected $io;
+	protected ConsoleIo $io;
 
 	/**
 	 * @return string

--- a/src/Command/DbIntegrityIntsCommand.php
+++ b/src/Command/DbIntegrityIntsCommand.php
@@ -26,10 +26,7 @@ class DbIntegrityIntsCommand extends Command {
 
 	use DbToolsTrait;
 
-	/**
-	 * @var \Cake\Console\Arguments
-	 */
-	protected $args;
+	protected Arguments $args;
 
 	/**
 	 * @return string

--- a/src/Command/DbResetCommand.php
+++ b/src/Command/DbResetCommand.php
@@ -18,15 +18,9 @@ class DbResetCommand extends Command {
 
 	use DbToolsTrait;
 
-	/**
-	 * @var \Cake\Console\Arguments
-	 */
-	protected $args;
+	protected Arguments $args;
 
-	/**
-	 * @var \Cake\Console\ConsoleIo
-	 */
-	protected $io;
+	protected ConsoleIo $io;
 
 	/**
 	 * @return string

--- a/src/Command/DbWipeCommand.php
+++ b/src/Command/DbWipeCommand.php
@@ -18,15 +18,9 @@ class DbWipeCommand extends Command {
 
 	use DbToolsTrait;
 
-	/**
-	 * @var \Cake\Console\Arguments
-	 */
-	protected $args;
+	protected Arguments $args;
 
-	/**
-	 * @var \Cake\Console\ConsoleIo
-	 */
-	protected $io;
+	protected ConsoleIo $io;
 
 	/**
 	 * @return string


### PR DESCRIPTION
## Summary

CakePHP 5.next ([cakephp/cakephp#19280](https://github.com/cakephp/cakephp/pull/19280)) adds typed `Arguments $args` and `ConsoleIo $io` properties on `BaseCommand`. Subclasses here redeclared them as untyped (`protected $args;` / `protected $io;`), which fatals on 5.next:

```
Fatal error: Type of Setup\Command\DbInitCommand::$args must be Cake\Console\Arguments
(as in class Cake\Console\BaseCommand)
```

Typing them in the subclasses is invariant with the upcoming parent declaration and fully compatible with 5.x, so this is the safe forward-compatible fix.

Affected commands:

- `DbInitCommand`
- `DbBackupCreateCommand`
- `DbBackupRestoreCommand`
- `DbResetCommand`
- `DbWipeCommand`
- `DbIntegrityIntsCommand` (only `$args`)