### PR TITLE
Make admin UI CSP-compatible (postLink → postButton)

### DIFF
--- a/templates/Admin/Backend/cache.php
+++ b/templates/Admin/Backend/cache.php
@@ -30,7 +30,7 @@ use Cake\I18n\DateTime;
 				<small>(<?php echo $this->Time->timeAgoInWords(new DateTime($data[$key])); ?>)</small>
 			<?php } ?>
 			<div>
-			<?php echo $this->Form->postLink('Store current time for testing', ['?' => ['key' => $key]], ['class' => 'button primary btn btn-primary']); ?>
+			<?php echo $this->Form->postButton('Store current time for testing', ['?' => ['key' => $key]], ['class' => 'button primary btn btn-primary', 'form' => ['class' => 'd-inline']]); ?>
 			</div>
 		</div>
 

--- a/templates/Admin/Backend/cookies.php
+++ b/templates/Admin/Backend/cookies.php
@@ -25,10 +25,26 @@ foreach ($cookies->getIterator() as $cookie) {
 	echo '<p>';
 	echo 'Expires: ' . ($expireDateTime ? $this->Time->nice($expireDateTime) : 'n/a');
 
-	echo ' ' . $this->Form->postLink('Delete', ['?' => ['cookie' => $cookie->getName()]], ['class' => 'btn btn-danger', 'confirm' => 'Sure?', 'block' => true]);
+	echo ' ' . $this->Form->postButton('Delete', ['?' => ['cookie' => $cookie->getName()]], [
+		'class' => 'btn btn-danger',
+		'form' => [
+			'class' => 'd-inline',
+			'data-confirm-message' => 'Sure?',
+		],
+	]);
 	echo '</p>';
 }
 
 ?>
 
 </div>
+<?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+	form.addEventListener('submit', function(e) {
+		if (!confirm(this.dataset.confirmMessage)) {
+			e.preventDefault();
+		}
+	});
+});
+</script>

--- a/templates/Admin/Setup/maintenance.php
+++ b/templates/Admin/Setup/maintenance.php
@@ -24,9 +24,9 @@
 	<p>
 		<?php
 		if (!$isMaintenanceModeEnabled) {
-			echo $this->Form->postLink('Go to Maintenance mode', ['action' => 'maintenance', '?' => ['maintenance' => 1]], ['class' => 'btn btn-danger']);
+			echo $this->Form->postButton('Go to Maintenance mode', ['action' => 'maintenance', '?' => ['maintenance' => 1]], ['class' => 'btn btn-danger', 'form' => ['class' => 'd-inline']]);
 		} else {
-			echo $this->Form->postLink('Leave Maintenance mode', ['action' => 'maintenance', '?' => ['maintenance' => 0]], ['class' => 'btn btn-warning']);
+			echo $this->Form->postButton('Leave Maintenance mode', ['action' => 'maintenance', '?' => ['maintenance' => 0]], ['class' => 'btn btn-warning', 'form' => ['class' => 'd-inline']]);
 		}
 		?>
 


### PR DESCRIPTION
## Summary

- Replace every `Form->postLink` with `Form->postButton` across the admin templates (`maintenance.php`, `cookies.php`, `cache.php`). `postLink` emits `onclick="document.getElementById('post_X').submit()"` on the `<a>`, which CSP blocks without `'unsafe-inline'` / `'unsafe-hashes'`. `postButton` emits a `<form>` + `<button type="submit">` — zero inline event handlers.
- Move the 'Delete cookie' confirmation prompt from the postLink `'confirm'` option to a `form[data-confirm-message]` data attribute plus a small JS delegate at the end of the cookies template (with CSP nonce handling).

## Motivation

Inline event handlers (`onclick=`, `onchange=`, ...) are blocked under a strict CSP without `'unsafe-inline'` / `'unsafe-hashes'`. Per the CSP spec, the `nonce` directive does **not** cover inline event handlers — only inline `<script>`/`<style>` blocks.

Note: passing `'confirm' => X` to `postButton` re-introduces an inline `onclick` on the button (same code path as postLink), so the confirm message has to move to a `data-*` attribute and a delegated submit handler.

## Before / after

```diff
- echo ' ' . $this->Form->postLink('Delete', ['?' => ['cookie' => $cookie->getName()]], [
-     'class' => 'btn btn-danger',
-     'confirm' => 'Sure?',
-     'block' => true,
- ]);
+ echo ' ' . $this->Form->postButton('Delete', ['?' => ['cookie' => $cookie->getName()]], [
+     'class' => 'btn btn-danger',
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => 'Sure?',
+     ],
+ ]);
```

Plus a delegated submit handler at the end of the template:

```php
<?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
    form.addEventListener('submit', function(e) {
        if (!confirm(this.dataset.confirmMessage)) {
            e.preventDefault();
        }
    });
});
</script>
```

## Host app nonce setup

Apps that want to benefit from the new nonce support set a `cspNonce` request attribute in a middleware. If no `cspNonce` attribute is present, the `<script>` tag renders without the `nonce` attribute — apps on permissive CSP continue to work unchanged.

## Scope

Only plugin runtime templates under `templates/Admin/` are touched. Bake generator `.twig` templates are left untouched — those generate host-app templates, not plugin output, and host apps can bake fresh from a later templates update.

## Verified

- Template grep: 0 `Form->postLink` calls in runtime admin templates, 0 inline `on*=` event handlers.
- Behaviour unchanged: delete cookie still prompts 'Sure?' before firing the POST.