### PR TITLE
Use request object instead of $_REQUEST in UptimeController

### DIFF
--- a/src/Controller/Admin/UptimeController.php
+++ b/src/Controller/Admin/UptimeController.php
@@ -30,13 +30,13 @@ class UptimeController extends AppController {
 	 * @return \Cake\Http\Response|null
 	 */
 	public function index() {
-		$response = '';
-		if (!isset($_REQUEST['key'])) {
+		$key = $this->request->getQuery('key');
+		if ($key === null) {
 			$response = 'OK';
+		} elseif (is_string($key) && preg_match('/^[a-f0-9]{32}$/', $key)) {
+			$response = $key;
 		} else {
-			if (preg_match('/^[a-f0-9]{32}$/', $_REQUEST['key'])) {
-				$response = $_REQUEST['key'];
-			}
+			$response = '';
 		}
 
 		return $this->response->withStringBody($response);


### PR DESCRIPTION
## Issue

`src/Controller/Admin/UptimeController.php` read `$_REQUEST['key']` directly, bypassing CakePHP's request abstraction. `$_REQUEST` also pulls in cookie values, so a cookie named `key` would shadow the query/post value unexpectedly.

The existing hex-32 regex (`^[a-f0-9]{32}$`) keeps the echoed response XSS-safe in practice, so this is a low-severity finding — but the access pattern is wrong by convention and a strict auditor will flag it.

## Fix

```diff
- if (!isset($_REQUEST['key'])) {
+ $key = $this->request->getQuery('key');
+ if ($key === null) {
```

Behavior preserved:
- no `key` param → `OK`
- `key` is hex-32 → echo back the key
- `key` anything else → empty body

The only narrow behavior change is dropping POST/cookie reads. Uptime probes are GET, so real usage is unaffected.
