### PR TITLE
Escape shell args in DB backup commands and confine restore path

### DIFF
--- a/src/Command/DbBackupCreateCommand.php
+++ b/src/Command/DbBackupCreateCommand.php
@@ -65,11 +65,11 @@ class DbBackupCreateCommand extends Command {
 		$file = $this->_path() . 'backup_' . date('Y-m-d--H-i-s');
 
 		$optionStrings = [
-			'--user="' . ($config['username'] ?? '') . '"',
-			'--password="' . ($config['password'] ?? '') . '"',
-			'--default-character-set=' . ($config['encoding'] ?? 'utf8'),
-			'--host=' . ($config['host'] ?? 'localhost'),
-			'--databases ' . $config['database'],
+			'--user=' . escapeshellarg((string)($config['username'] ?? '')),
+			'--password=' . escapeshellarg((string)($config['password'] ?? '')),
+			'--default-character-set=' . escapeshellarg((string)($config['encoding'] ?? 'utf8')),
+			'--host=' . escapeshellarg((string)($config['host'] ?? 'localhost')),
+			'--databases ' . escapeshellarg((string)$config['database']),
 			'--no-create-db',
 		];
 		if ($args->getOption('no-data')) {
@@ -91,7 +91,7 @@ class DbBackupCreateCommand extends Command {
 			foreach ($sources as $key => $val) {
 				$sources[$key] = $usePrefix . $val;
 			}
-			$optionStrings[] = '--tables ' . implode(' ', $sources);
+			$optionStrings[] = '--tables ' . implode(' ', array_map('escapeshellarg', $sources));
 			$file .= '_custom';
 		} elseif ($usePrefix) {
 			foreach ($sources as $key => $source) {
@@ -99,7 +99,7 @@ class DbBackupCreateCommand extends Command {
 					unset($sources[$key]);
 				}
 			}
-			$optionStrings[] = '--tables ' . implode(' ', $sources);
+			$optionStrings[] = '--tables ' . implode(' ', array_map('escapeshellarg', $sources));
 			$file .= '_' . rtrim($usePrefix, '_');
 		}
 		$file .= '.sql';
@@ -107,7 +107,7 @@ class DbBackupCreateCommand extends Command {
 			$optionStrings[] = '| gzip';
 			$file .= '.gz';
 		}
-		$optionStrings[] = '> ' . $file;
+		$optionStrings[] = '> ' . escapeshellarg($file);
 
 		$this->io->out('Backup will be written to:');
 		$this->io->out(' - ' . $this->_path());

--- a/src/Command/DbBackupRestoreCommand.php
+++ b/src/Command/DbBackupRestoreCommand.php
@@ -71,11 +71,11 @@ class DbBackupRestoreCommand extends Command {
 		}
 
 		$optionStrings = [
-			'--user="' . $config['username'] . '"',
-			'--password="' . $config['password'] . '"',
-			'--default-character-set=' . ($config['encoding'] ?? 'utf-8'),
-			'--host=' . $config['host'],
-			'' . $config['database'],
+			'--user=' . escapeshellarg((string)($config['username'] ?? '')),
+			'--password=' . escapeshellarg((string)($config['password'] ?? '')),
+			'--default-character-set=' . escapeshellarg((string)($config['encoding'] ?? 'utf-8')),
+			'--host=' . escapeshellarg((string)($config['host'] ?? 'localhost')),
+			escapeshellarg((string)$config['database']),
 		];
 
 		if ($this->args->getOption('verbose')) {
@@ -95,6 +95,15 @@ class DbBackupRestoreCommand extends Command {
 			$file = realpath($path);
 			if (!$file || !file_exists($file)) {
 				$this->io->abort(sprintf('Invalid file (path) `%s`', $path));
+			}
+			$baseReal = realpath(BACKUPS);
+			$base = $baseReal !== false ? $baseReal : rtrim(BACKUPS, DS);
+			if (!str_starts_with($file, rtrim($base, DS) . DS)) {
+				$this->io->abort(sprintf('Path `%s` is outside the allowed backup directory.', $path));
+			}
+			$ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
+			if (!in_array($ext, ['sql', 'gz'], true)) {
+				$this->io->abort(sprintf('File `%s` does not have a valid extension (.sql or .gz).', $path));
 			}
 
 			return $file;
@@ -146,9 +155,9 @@ class DbBackupRestoreCommand extends Command {
 		$command = $this->_command('mysql');
 
 		if (str_contains($file, '.gz') || $this->args->getOption('compress')) {
-			$command = $this->_command('gunzip') . ' < ' . $file . ' | ' . $command;
+			$command = $this->_command('gunzip') . ' < ' . escapeshellarg($file) . ' | ' . $command;
 		} else {
-			$optionStrings[] = '< ' . $file;
+			$optionStrings[] = '< ' . escapeshellarg($file);
 		}
 
 		if (!empty($optionStrings)) {


### PR DESCRIPTION
## Summary

Two related hardenings of the CLI backup/restore commands:

- **Shell injection via DB credentials.** `DbBackupCreateCommand` and `DbBackupRestoreCommand` interpolated the connection's username/password/host/encoding/database directly into the strings passed to `exec()`. Any of those values containing a double quote or shell metacharacter could break out of the quoted argument and execute arbitrary commands. They are now wrapped with `escapeshellarg()`, along with the per-table `--tables` list and the redirect/pipe targets.
- **Restore path traversal.** `DbBackupRestoreCommand::_getFile()` previously accepted any absolute path on disk via `--path`, only checking that the file existed. The resolved real path is now required to live under `BACKUPS` and to end in `.sql` or `.gz`; otherwise the command aborts with a clear message.

Long-term these commands should call mysql/mysqldump via `proc_open()` with an argv array to eliminate shell parsing entirely; this PR is the minimal, behaviour-preserving fix.