### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/setup.pot
+++ b/resources/locales/setup.pot
@@ -1,0 +1,106 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 03:25+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Password to Hash (2 characters at least)"
+msgstr ""
+
+msgid "Maintenance mode active - your IP {0} is in the whitelist."
+msgstr ""
+
+msgid "activated"
+msgstr ""
+
+msgid "deactivated"
+msgstr ""
+
+msgid "Maintenance mode {0}"
+msgstr ""
+
+msgid "Maintenance mode not {0}"
+msgstr ""
+
+msgid "debug set to {0}"
+msgstr ""
+
+msgid "debug not set"
+msgstr ""
+
+msgid "cache cleared"
+msgstr ""
+
+msgid "cache not cleared"
+msgstr ""
+
+msgid "session cleared"
+msgstr ""
+
+msgid "session not cleared"
+msgstr ""
+
+msgid "layout {0} activated"
+msgstr ""
+
+msgid "DB Tables"
+msgstr ""
+
+msgid "Disk Space"
+msgstr ""
+
+msgid "Locale"
+msgstr ""
+
+msgid "Chose desired result"
+msgstr ""
+
+msgid "e.g. de_DE.utf8"
+msgstr ""
+
+msgid "Result"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Test forms"
+msgstr ""
+
+msgid "Days"
+msgstr ""
+
+msgid "Hours"
+msgstr ""
+
+msgid "Minutes"
+msgstr ""
+
+msgid "Memory"
+msgstr ""
+
+msgid "System"
+msgstr ""
+
+msgid "Timezones"
+msgstr ""
+
+msgid "Locales"
+msgstr ""
+
+msgid "ENV Config"
+msgstr ""
+
+msgid "IP Info"
+msgstr ""
+

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -96,7 +96,7 @@ Note that you can define the constant CLASS_USERS in your bootstrap to point to 
 			$pwdToHash = $pwd;
 		}
 		while (!$pwdToHash || mb_strlen($pwdToHash) < 2) {
-			$pwdToHash = $io->ask(__('Password to Hash (2 characters at least)'));
+			$pwdToHash = $io->ask(__d('setup', 'Password to Hash (2 characters at least)'));
 		}
 		$io->hr();
 		$io->out('Password:');

--- a/templates/Admin/Backend/database.php
+++ b/templates/Admin/Backend/database.php
@@ -8,7 +8,7 @@
 ?>
 <div class="columns col-md-12">
 
-<h1><?php echo count($dbTables); ?> <?php echo __('DB Tables');?></h1>
+<h1><?php echo count($dbTables); ?> <?php echo __d('setup', 'DB Tables');?></h1>
 <p>Excluding phinxlog migration tables</p>
 <p>Database size: <?php echo $this->Number->toReadableSize($dbSize); ?></p>
 

--- a/templates/Admin/Backend/disk_space.php
+++ b/templates/Admin/Backend/disk_space.php
@@ -7,7 +7,7 @@
 ?>
 <div class="col-md-12">
 
-<h2><?php echo __('Disk Space'); ?></h2>
+<h2><?php echo __d('setup', 'Disk Space'); ?></h2>
 
 <?php
 	$pos = count($space['app']) - 1;

--- a/templates/Admin/Backend/locales.php
+++ b/templates/Admin/Backend/locales.php
@@ -8,28 +8,28 @@
 ?>
 <div class="index col-md-12">
 
-<h2><?php echo __('Locale');?></h2>
+<h2><?php echo __d('setup', 'Locale');?></h2>
 
 <h3>Test Locale</h3>
 <?php echo $this->Form->create();?>
 	<fieldset>
-		<legend><?php echo __('Chose desired result'); ?></legend>
+		<legend><?php echo __d('setup', 'Chose desired result'); ?></legend>
 	<?php
 		echo $this->Form->control('Form.format');
 
-		echo $this->Form->control('Form.locale', ['placeholder' => __('e.g. de_DE.utf8')]);
+		echo $this->Form->control('Form.locale', ['placeholder' => __d('setup', 'e.g. de_DE.utf8')]);
 	?>
 	</fieldset>
 <?php if (isset($result)) { ?>
 	<fieldset>
-		<legend><?php echo __('Result');?></legend>
+		<legend><?php echo __d('setup', 'Result');?></legend>
 		<?php
 			echo pre($result);
 		?>
 	</fieldset>
 <?php } ?>
 
-<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+<?php echo $this->Form->submit(__d('setup', 'Submit')); echo $this->Form->end();?>
 
 <h3>System Locales</h3>
 

--- a/templates/Admin/Backend/timezones.php
+++ b/templates/Admin/Backend/timezones.php
@@ -54,21 +54,21 @@
 
 		<?php echo $this->Form->create($token);?>
 		<fieldset>
-			<legend><?php echo __('Test forms'); ?></legend>
+			<legend><?php echo __d('setup', 'Test forms'); ?></legend>
 			<?php
 			echo $this->Form->control('created', ['label' => 'DateTime']);
 			?>
 		</fieldset>
 		<?php if (isset($result)) { ?>
 			<fieldset>
-				<legend><?php echo __('Result');?></legend>
+				<legend><?php echo __d('setup', 'Result');?></legend>
 				<?php
 				echo pre($result);
 				?>
 			</fieldset>
 		<?php } ?>
 
-		<?php echo $this->Form->submit(__('Submit')); echo $this->Form->end();?>
+		<?php echo $this->Form->submit(__d('setup', 'Submit')); echo $this->Form->end();?>
 
 	<?php } else {
 		echo '<i>Add Tools plugin to see how forms interact with timezone config.</i>';

--- a/templates/Admin/Configuration/index.php
+++ b/templates/Admin/Configuration/index.php
@@ -17,13 +17,13 @@ use Setup\Utility\System;
 	<h3>Server info</h3>
 	Server-Uptime:
 	<?php if (!empty($uptime)) { ?>
-		<?php echo $uptime['days'];?> <?php echo __('Days'); ?>, <?php echo $uptime['hours'];?> <?php echo __('Hours'); ?>, <?php echo $uptime['mins'];?> <?php echo __('Minutes'); ?>
+		<?php echo $uptime['days'];?> <?php echo __d('setup', 'Days'); ?>, <?php echo $uptime['hours'];?> <?php echo __d('setup', 'Hours'); ?>, <?php echo $uptime['mins'];?> <?php echo __d('setup', 'Minutes'); ?>
 	<?php } else { ?>
 		<i>n/a (only for unix/linux server)</i>
 	<?php } ?>
 	<br /><br />
 	Load averages for server: <?php echo ($serverLoad); ?><br />
-	<?php echo __('Memory'); ?>: <?php echo ($memory); ?>
+	<?php echo __d('setup', 'Memory'); ?>: <?php echo ($memory); ?>
 	<br />
 	Current Memory Usage (Single User): <?php echo $this->Number->toReadableSize(Debug::memoryUsage()).' (Peak: '.$this->Number->toReadableSize(Debug::peakMemoryUsage()).')'; ?>
 
@@ -57,24 +57,24 @@ use Setup\Utility\System;
 
 
 <?php /*
-		<li><?php echo $this->Html->link(__('Disk Space'), ['action'=>'disk_space']); ?></li>
-		<li><?php echo $this->Html->link(__('Environment & Database'), ['action'=>'environment']); ?></li>
-		<li><?php echo $this->Html->link(__('Setup (Folder and Rights)'), ['action'=>'setup']); ?></li>
-		<li><?php echo $this->Html->link(__('Check Mail'), ['action'=>'check_mail']); ?></li>
-		<li><?php echo $this->Html->link(__('Configuration Parameters (Status)'), ['action'=>'status']); ?></li>
-		<li><?php echo $this->Html->link(__('All Set Constants'), ['action'=>'constants']); ?></li>
-		<li><?php echo $this->Html->link(__('Superglobals (GET, POST, SESSION etc)'), ['action'=>'superglobals']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Disk Space'), ['action'=>'disk_space']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Environment & Database'), ['action'=>'environment']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Setup (Folder and Rights)'), ['action'=>'setup']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Check Mail'), ['action'=>'check_mail']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Configuration Parameters (Status)'), ['action'=>'status']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'All Set Constants'), ['action'=>'constants']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Superglobals (GET, POST, SESSION etc)'), ['action'=>'superglobals']); ?></li>
 
-		<li><?php echo $this->Html->link(__('Session Infos (Duration)'), ['action'=>'session']); ?></li>
-		<li><?php echo $this->Html->link(__('Clear Session (Interactive)'), ['action'=>'clearsession']); ?></li>
-		<li><?php echo $this->Html->link(__('Clear Cookies (Interactive)'), ['action'=>'clearcookies']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Session Infos (Duration)'), ['action'=>'session']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Clear Session (Interactive)'), ['action'=>'clearsession']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Clear Cookies (Interactive)'), ['action'=>'clearcookies']); ?></li>
 
-		<li><?php echo $this->Html->link(__('Sql Dump, Backup, Restore'), ['action'=>'sql']); ?></li>
-		<li><?php echo $this->Html->link(__('Cache'), ['action'=>'cache']); ?></li>
-		<li><?php echo $this->Html->link(__('Clear Cache (With full output)'), ['action'=>'clearcache']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Sql Dump, Backup, Restore'), ['action'=>'sql']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Cache'), ['action'=>'cache']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Clear Cache (With full output)'), ['action'=>'clearcache']); ?></li>
 
-		<li><?php echo $this->Html->link(__('Log Files'), ['action'=>'logs']); ?></li>
-		<li><?php echo $this->Html->link(__('Server Log Files'), ['action'=>'serverlogs']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Log Files'), ['action'=>'logs']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Server Log Files'), ['action'=>'serverlogs']); ?></li>
 */ ?>
 
 <div class="actions">

--- a/templates/Admin/Database/foreign_keys.php
+++ b/templates/Admin/Database/foreign_keys.php
@@ -9,7 +9,7 @@ use Cake\Utility\Inflector;
 ?>
 <div class="columns col-md-12">
 
-<h1><?php echo count($tables); ?> <?php echo __('DB Tables');?></h1>
+<h1><?php echo count($tables); ?> <?php echo __d('setup', 'DB Tables');?></h1>
 
 <p>The following infos are just guesses based on CakePHP conventions.</p>
 

--- a/templates/Admin/Setup/index.php
+++ b/templates/Admin/Setup/index.php
@@ -16,13 +16,13 @@
 		<li><?php echo $this->Html->link('Cache Info and Testing', ['controller' => 'Backend', 'action' => 'cache']);?></li>
 		<li><?php echo $this->Html->link('ORM Type Map', ['controller' => 'Backend', 'action' => 'typeMap']); ?></li>
 
-		<li><?php echo $this->Html->link(__('System'), ['controller' => 'Backend', 'action' => 'system']); ?></li>
-		<li><?php echo $this->Html->link(__('Timezones'), ['controller' => 'Backend', 'action' => 'timezones']);?></li>
-		<li><?php echo $this->Html->link(__('Locales'), ['controller' => 'Backend', 'action' => 'locales']);?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'System'), ['controller' => 'Backend', 'action' => 'system']); ?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Timezones'), ['controller' => 'Backend', 'action' => 'timezones']);?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Locales'), ['controller' => 'Backend', 'action' => 'locales']);?></li>
 		<li><?php echo $this->Html->link('Database Info', ['controller' => 'Backend', 'action' => 'database']);?></li>
-		<li><?php echo $this->Html->link(__('Disk Space'), ['controller' => 'Backend', 'action' => 'diskSpace']);?></li>
-		<li><?php echo $this->Html->link(__('ENV Config'), ['controller' => 'Backend', 'action' => 'env']);?></li>
-		<li><?php echo $this->Html->link(__('IP Info'), ['controller' => 'Backend', 'action' => 'ip']);?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'Disk Space'), ['controller' => 'Backend', 'action' => 'diskSpace']);?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'ENV Config'), ['controller' => 'Backend', 'action' => 'env']);?></li>
+		<li><?php echo $this->Html->link(__d('setup', 'IP Info'), ['controller' => 'Backend', 'action' => 'ip']);?></li>
 	</ul>
 
 


### PR DESCRIPTION
## Summary

- Convert 35 `__()` calls in `src/` and runtime `templates/` to `__d('setup', ...)` so plugin strings live in their own domain.
- The 12 pre-existing `__d('setup', ...)` calls already pointed at the right domain.
- The 1 `__d('cake', 'Error')` call in `templates/element/l10n_panel.php` is intentionally left alone — it lives in a debug panel that *demonstrates* how the `cake` core domain resolves.
- The bake twig templates under `templates/bake/` are deliberately **not** converted — they emit scaffold code into the user's own application, so their `__()` calls should land in the user's app `default` domain, not in this plugin's domain.
- Add `resources/locales/setup.pot` (30 unique msgids) generated via `bin/cake i18n extract` (with `templates/bake/` excluded for the same reason).

## Why

Plugin runtime strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 232 / 232 (2 pre-existing notices, 12 skipped — unrelated to this change)
- phpstan: no errors
- phpcs: clean