### PR TITLE
Add cache benchmark page and refactor cache config layout

### DIFF
--- a/src/Controller/Admin/BackendController.php
+++ b/src/Controller/Admin/BackendController.php
@@ -243,28 +243,22 @@ SQL;
 	}
 
 	/**
-	 * @return \Cake\Http\Response|null|void
+	 * @return void
 	 */
-	public function cacheBenchmark() {
+	public function cacheBenchmark(): void {
 		$bench = new CacheBenchmark();
 		$availability = $bench->availableEngines();
 
-		$availableNames = [];
-		$unavailable = [];
-		foreach ($availability as $name => $entry) {
-			if ($entry['available']) {
-				$availableNames[] = $name;
-			} else {
-				$unavailable[$name] = $entry['reason'] ?? '';
-			}
-		}
-
 		$results = null;
 		if ($this->request->is(['post', 'put'])) {
+			$availableNames = array_keys(array_filter(
+				$availability,
+				fn (array $entry): bool => $entry['available'],
+			));
 			$results = $bench->run($availableNames);
 		}
 
-		$this->set(compact('availability', 'availableNames', 'unavailable', 'results'));
+		$this->set(compact('availability', 'results'));
 	}
 
 	/**

--- a/src/Controller/Admin/BackendController.php
+++ b/src/Controller/Admin/BackendController.php
@@ -11,6 +11,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\I18n\DateTime;
 use Cake\ORM\TableRegistry;
 use PDO;
+use Setup\Utility\CacheBenchmark;
 use Setup\Utility\Config;
 use Setup\Utility\Debug;
 use Setup\Utility\OrmTypes;
@@ -239,6 +240,31 @@ SQL;
 		}
 
 		$this->set(compact('caches', 'data'));
+	}
+
+	/**
+	 * @return \Cake\Http\Response|null|void
+	 */
+	public function cacheBenchmark() {
+		$bench = new CacheBenchmark();
+		$availability = $bench->availableEngines();
+
+		$availableNames = [];
+		$unavailable = [];
+		foreach ($availability as $name => $entry) {
+			if ($entry['available']) {
+				$availableNames[] = $name;
+			} else {
+				$unavailable[$name] = $entry['reason'] ?? '';
+			}
+		}
+
+		$results = null;
+		if ($this->request->is(['post', 'put'])) {
+			$results = $bench->run($availableNames);
+		}
+
+		$this->set(compact('availability', 'availableNames', 'unavailable', 'results'));
 	}
 
 	/**

--- a/src/Utility/CacheBenchmark.php
+++ b/src/Utility/CacheBenchmark.php
@@ -9,6 +9,7 @@ use Cake\Cache\Engine\ApcuEngine;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Cache\Engine\MemcachedEngine;
 use Cake\Cache\Engine\RedisEngine;
+use InvalidArgumentException;
 use Throwable;
 
 /**
@@ -27,6 +28,16 @@ class CacheBenchmark {
 	];
 
 	/**
+	 * @var int
+	 */
+	protected const READ_OPS = 1000;
+
+	/**
+	 * @var int
+	 */
+	protected const WRITE_OPS = 1000;
+
+	/**
 	 * Returns availability info for each known cache engine.
 	 *
 	 * @return array<string, array{available: bool, className: string, reason?: string}>
@@ -39,16 +50,6 @@ class CacheBenchmark {
 
 		return $result;
 	}
-
-	/**
-	 * @var int
-	 */
-	protected const READ_OPS = 1000;
-
-	/**
-	 * @var int
-	 */
-	protected const WRITE_OPS = 1000;
 
 	/**
 	 * @param array<string> $engineNames Subset of keys from availableEngines() where available === true
@@ -130,9 +131,14 @@ class CacheBenchmark {
 
 	/**
 	 * @param string $engine
+	 * @throws \InvalidArgumentException If $engine is not a known engine name
 	 * @return array<string, mixed>
 	 */
 	protected function buildConfig(string $engine): array {
+		if (!isset(static::ENGINE_CLASSES[$engine])) {
+			throw new InvalidArgumentException(sprintf('Unknown cache engine: %s', $engine));
+		}
+
 		$base = [
 			'className' => static::ENGINE_CLASSES[$engine],
 			'prefix' => 'setup_benchmark_',

--- a/src/Utility/CacheBenchmark.php
+++ b/src/Utility/CacheBenchmark.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setup\Utility;
+
+use Cake\Cache\Engine\ApcuEngine;
+use Cake\Cache\Engine\FileEngine;
+use Cake\Cache\Engine\MemcachedEngine;
+use Cake\Cache\Engine\RedisEngine;
+use Cake\Cache\Engine\WincacheEngine;
+
+/**
+ * Benchmark CakePHP cache engines and detect their availability.
+ */
+class CacheBenchmark {
+
+	/**
+	 * @var array<string, class-string>
+	 */
+	protected const ENGINE_CLASSES = [
+		'File' => FileEngine::class,
+		'Apcu' => ApcuEngine::class,
+		'Memcached' => MemcachedEngine::class,
+		'Redis' => RedisEngine::class,
+		'Wincache' => WincacheEngine::class,
+	];
+
+	/**
+	 * Returns availability info for each known cache engine.
+	 *
+	 * @return array<string, array{available: bool, className: string, reason?: string}>
+	 */
+	public function availableEngines(): array {
+		$result = [];
+		foreach (static::ENGINE_CLASSES as $name => $class) {
+			$result[$name] = $this->probe($name, $class);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Probe a single engine for availability based on PHP extension presence.
+	 *
+	 * @param string $name Short engine name (e.g. 'File', 'Redis')
+	 * @param class-string $class Fully-qualified engine class name
+	 * @return array{available: bool, className: string, reason?: string}
+	 */
+	protected function probe(string $name, string $class): array {
+		$base = ['className' => $class];
+
+		return match ($name) {
+			'File' => $base + ['available' => true],
+			'Apcu' => extension_loaded('apcu') && (bool)ini_get('apc.enabled')
+				? $base + ['available' => true]
+				: $base + ['available' => false, 'reason' => 'ext-apcu missing or apc.enabled=0'],
+			'Memcached' => extension_loaded('memcached')
+				? $base + ['available' => true]
+				: $base + ['available' => false, 'reason' => 'ext-memcached missing'],
+			'Redis' => extension_loaded('redis')
+				? $base + ['available' => true]
+				: $base + ['available' => false, 'reason' => 'ext-redis missing'],
+			'Wincache' => extension_loaded('wincache') && (bool)ini_get('wincache.ucenabled')
+				? $base + ['available' => true]
+				: $base + ['available' => false, 'reason' => 'ext-wincache missing or wincache.ucenabled=0'],
+			default => $base + ['available' => false, 'reason' => 'unknown engine'],
+		};
+	}
+
+}

--- a/src/Utility/CacheBenchmark.php
+++ b/src/Utility/CacheBenchmark.php
@@ -8,7 +8,6 @@ use Cake\Cache\Engine\ApcuEngine;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Cache\Engine\MemcachedEngine;
 use Cake\Cache\Engine\RedisEngine;
-use Cake\Cache\Engine\WincacheEngine;
 
 /**
  * Benchmark CakePHP cache engines and detect their availability.
@@ -23,7 +22,6 @@ class CacheBenchmark {
 		'Apcu' => ApcuEngine::class,
 		'Memcached' => MemcachedEngine::class,
 		'Redis' => RedisEngine::class,
-		'Wincache' => WincacheEngine::class,
 	];
 
 	/**
@@ -52,18 +50,15 @@ class CacheBenchmark {
 
 		return match ($name) {
 			'File' => $base + ['available' => true],
-			'Apcu' => extension_loaded('apcu') && (bool)ini_get('apc.enabled')
+			'Apcu' => extension_loaded('apcu')
 				? $base + ['available' => true]
-				: $base + ['available' => false, 'reason' => 'ext-apcu missing or apc.enabled=0'],
+				: $base + ['available' => false, 'reason' => 'ext-apcu missing'],
 			'Memcached' => extension_loaded('memcached')
 				? $base + ['available' => true]
 				: $base + ['available' => false, 'reason' => 'ext-memcached missing'],
 			'Redis' => extension_loaded('redis')
 				? $base + ['available' => true]
 				: $base + ['available' => false, 'reason' => 'ext-redis missing'],
-			'Wincache' => extension_loaded('wincache') && (bool)ini_get('wincache.ucenabled')
-				? $base + ['available' => true]
-				: $base + ['available' => false, 'reason' => 'ext-wincache missing or wincache.ucenabled=0'],
 			default => $base + ['available' => false, 'reason' => 'unknown engine'],
 		};
 	}

--- a/src/Utility/CacheBenchmark.php
+++ b/src/Utility/CacheBenchmark.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Setup\Utility;
 
+use Cake\Cache\Cache;
 use Cake\Cache\Engine\ApcuEngine;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Cache\Engine\MemcachedEngine;
 use Cake\Cache\Engine\RedisEngine;
+use Throwable;
 
 /**
  * Benchmark CakePHP cache engines and detect their availability.
@@ -36,6 +38,111 @@ class CacheBenchmark {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * @var int
+	 */
+	protected const READ_OPS = 1000;
+
+	/**
+	 * @var int
+	 */
+	protected const WRITE_OPS = 1000;
+
+	/**
+	 * @param array<string> $engineNames Subset of keys from availableEngines() where available === true
+	 * @return array<string, array<string, array{ms: float, opsPerSec: float}|array{error: string}>>
+	 */
+	public function run(array $engineNames): array {
+		$payload = str_repeat('x', 100); // ~100B
+		$results = [];
+
+		foreach ($engineNames as $engine) {
+			$results[$engine] = $this->runEngine($engine, $payload);
+		}
+
+		return $results;
+	}
+
+	/**
+	 * @param string $engine
+	 * @param string $payload
+	 * @return array<string, array{ms: float, opsPerSec: float}|array{error: string}>
+	 */
+	protected function runEngine(string $engine, string $payload): array {
+		$configName = '_setup_benchmark_' . $engine;
+		$result = [];
+
+		$readDone = false;
+		try {
+			Cache::setConfig($configName, $this->buildConfig($engine));
+
+			// Pre-populate read keyspace (silent, not measured)
+			for ($i = 0; $i < static::READ_OPS; $i++) {
+				Cache::write('bench_read_' . $i, $payload, $configName);
+			}
+
+			// Read benchmark
+			$start = hrtime(true);
+			for ($i = 0; $i < static::READ_OPS; $i++) {
+				Cache::read('bench_read_' . $i, $configName);
+			}
+			$result['read'] = $this->measure($start, static::READ_OPS);
+			$readDone = true;
+
+			// Write benchmark (separate keyspace from read keys)
+			$start = hrtime(true);
+			for ($i = 0; $i < static::WRITE_OPS; $i++) {
+				Cache::write('bench_write_' . $i, $payload, $configName);
+			}
+			$result['write'] = $this->measure($start, static::WRITE_OPS);
+		} catch (Throwable $e) {
+			$message = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
+			if (!$readDone) {
+				$result['read'] = ['error' => $message];
+			}
+			$result['write'] = ['error' => $message];
+		} finally {
+			try {
+				Cache::clear($configName);
+			} catch (Throwable) {
+				// best-effort cleanup
+			}
+			Cache::drop($configName);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param int $start hrtime(true) start
+	 * @param int $ops
+	 * @return array{ms: float, opsPerSec: float}
+	 */
+	protected function measure(int $start, int $ops): array {
+		$ns = hrtime(true) - $start;
+		$ms = $ns / 1_000_000;
+		$opsPerSec = $ms > 0 ? $ops / ($ms / 1000) : 0.0;
+
+		return ['ms' => round($ms, 2), 'opsPerSec' => round($opsPerSec, 0)];
+	}
+
+	/**
+	 * @param string $engine
+	 * @return array<string, mixed>
+	 */
+	protected function buildConfig(string $engine): array {
+		$base = [
+			'className' => static::ENGINE_CLASSES[$engine],
+			'prefix' => 'setup_benchmark_',
+			'duration' => '+5 minutes',
+		];
+
+		return match ($engine) {
+			'File' => $base + ['path' => TMP . 'cache' . DS . 'setup_benchmark' . DS],
+			default => $base,
+		};
 	}
 
 	/**

--- a/templates/Admin/Backend/cache.php
+++ b/templates/Admin/Backend/cache.php
@@ -6,41 +6,80 @@
  */
 
 use Cake\Core\App;
-use Cake\Error\Debugger;
 use Cake\I18n\DateTime;
+
 ?>
 
 <div class="columns col-md-12">
 
 <h1>Cache Config</h1>
 
-<div class="actions">
-<ul>
-	<?php foreach ($caches as $key => $config) { ?>
-		<?php
-		$engineClass = $config['className'];
-		$engine = App::shortName($engineClass, 'Cache/Engine', 'Engine');
-		?>
-	<li>
-		<h2>[<?php echo h($engine); ?>] <?php echo h($key); ?></h2>
+<p>
+	<?php echo $this->Html->link(
+		'Compare all engines on this host →',
+		['action' => 'cacheBenchmark'],
+		['class' => 'btn btn-outline-primary btn-sm'],
+	); ?>
+</p>
 
-		<div>
-			Data: <?php echo Debugger::exportVar($data[$key]); ?>
-			<?php if ($data[$key]) { ?>
-				<small>(<?php echo $this->Time->timeAgoInWords(new DateTime($data[$key])); ?>)</small>
-			<?php } ?>
-			<div>
-			<?php echo $this->Form->postButton('Store current time for testing', ['?' => ['key' => $key]], ['class' => 'button primary btn btn-primary', 'form' => ['class' => 'd-inline']]); ?>
-			</div>
-		</div>
+<table class="table table-striped">
+	<thead>
+		<tr>
+			<th>Config</th>
+			<th>Engine</th>
+			<th>Groups</th>
+			<th>Duration</th>
+			<th>Prefix / Path / Host</th>
+			<th>Last test value</th>
+			<th>Actions</th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php foreach ($caches as $key => $config) { ?>
+			<?php
+			$engineClass = $config['className'];
+			$engine = App::shortName($engineClass, 'Cache/Engine', 'Engine');
+			$groups = isset($config['groups']) && $config['groups'] ? implode(', ', $config['groups']) : '—';
 
-		<details style="margin-bottom: 12px">
-			<summary>Details</summary>
-		<pre><?php echo print_r($config, true); ?></pre>
-		</details>
-	</li>
-	<?php } ?>
-</ul>
-</div>
+			$location = '—';
+			if (isset($config['path'])) {
+				$location = $config['path'];
+			} elseif (isset($config['host'])) {
+				$port = isset($config['port']) ? ':' . $config['port'] : '';
+				$location = $config['host'] . $port;
+			} elseif (isset($config['prefix'])) {
+				$location = $config['prefix'];
+			}
+			?>
+			<tr>
+				<td><strong><?php echo h($key); ?></strong></td>
+				<td><code><?php echo h($engine); ?></code></td>
+				<td><?php echo h($groups); ?></td>
+				<td><?php echo h($config['duration'] ?? '—'); ?></td>
+				<td><small><?php echo h($location); ?></small></td>
+				<td>
+					<?php if ($data[$key]) { ?>
+						<?php echo h($data[$key]); ?>
+						<br>
+						<small><?php echo $this->Time->timeAgoInWords(new DateTime($data[$key])); ?></small>
+					<?php } else { ?>
+						—
+					<?php } ?>
+				</td>
+				<td>
+					<?php echo $this->Form->postButton(
+						'Store test',
+						['?' => ['key' => $key]],
+						['class' => 'btn btn-sm btn-primary', 'form' => ['class' => 'd-inline']],
+					); ?>
+					<details class="d-inline-block ms-2">
+						<summary>Details</summary>
+						<pre><?php echo h(print_r($config, true)); ?></pre>
+					</details>
+				</td>
+			</tr>
+		<?php } ?>
+	</tbody>
+</table>
 
 </div>

--- a/templates/Admin/Backend/cache_benchmark.php
+++ b/templates/Admin/Backend/cache_benchmark.php
@@ -24,7 +24,7 @@ $unavailable = array_filter($availability, fn (array $entry): bool => !$entry['a
 	then time 1000 reads. Then time 1000 writes into a separate "write" keyspace, so the read measurement is not tainted by warm engine state from a write loop.
 </p>
 
-<div class="actions" style="margin: 12px 0">
+<div class="actions">
 	<?php echo $this->Form->postButton(
 		$results === null ? 'Run benchmark' : 'Run again',
 		[],

--- a/templates/Admin/Backend/cache_benchmark.php
+++ b/templates/Admin/Backend/cache_benchmark.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<string, array{available: bool, className: string, reason?: string}> $availability
+ * @var array<string> $availableNames
+ * @var array<string, string> $unavailable
+ * @var array<string, array<string, array{ms: float, opsPerSec: float}|array{error: string}>>|null $results
+ */
+// placeholder - full implementation in Task 4
+foreach ($availability as $name => $entry) {
+	echo h($name) . PHP_EOL;
+}
+if ($results !== null) {
+	foreach ($results as $engineName => $ops) {
+		echo h($engineName) . PHP_EOL;
+	}
+}

--- a/templates/Admin/Backend/cache_benchmark.php
+++ b/templates/Admin/Backend/cache_benchmark.php
@@ -2,8 +2,6 @@
 /**
  * @var \App\View\AppView $this
  * @var array<string, array{available: bool, className: string, reason?: string}> $availability
- * @var array<string> $availableNames
- * @var array<string, string> $unavailable
  * @var array<string, array<string, array{ms: float, opsPerSec: float}|array{error: string}>>|null $results
  */
 // placeholder - full implementation in Task 4

--- a/templates/Admin/Backend/cache_benchmark.php
+++ b/templates/Admin/Backend/cache_benchmark.php
@@ -4,12 +4,100 @@
  * @var array<string, array{available: bool, className: string, reason?: string}> $availability
  * @var array<string, array<string, array{ms: float, opsPerSec: float}|array{error: string}>>|null $results
  */
-// placeholder - full implementation in Task 4
-foreach ($availability as $name => $entry) {
-	echo h($name) . PHP_EOL;
-}
-if ($results !== null) {
-	foreach ($results as $engineName => $ops) {
-		echo h($engineName) . PHP_EOL;
+
+use Cake\Core\App;
+
+$unavailable = array_filter($availability, fn (array $entry): bool => !$entry['available']);
+?>
+
+<div class="columns col-md-12">
+
+<h1>Cache Benchmark</h1>
+
+<p>
+	Compare read/write performance across all CakePHP cache engines available on this host.
+	Each engine runs in an isolated throwaway config (prefix <code>setup_benchmark_</code>) — your real cache configs are not touched.
+</p>
+
+<p>
+	<strong>Method:</strong> for each engine, pre-populate 1000 small (~100B) values into a "read" keyspace,
+	then time 1000 reads. Then time 1000 writes into a separate "write" keyspace, so the read measurement is not tainted by warm engine state from a write loop.
+</p>
+
+<div class="actions" style="margin: 12px 0">
+	<?php echo $this->Form->postButton(
+		$results === null ? 'Run benchmark' : 'Run again',
+		[],
+		['class' => 'button primary btn btn-primary'],
+	); ?>
+</div>
+
+<?php if ($results !== null) { ?>
+	<?php
+	$fastestRead = null;
+	$fastestWrite = null;
+	foreach ($results as $row) {
+		if (isset($row['read']['ms']) && ($fastestRead === null || $row['read']['ms'] < $fastestRead)) {
+			$fastestRead = $row['read']['ms'];
+		}
+		if (isset($row['write']['ms']) && ($fastestWrite === null || $row['write']['ms'] < $fastestWrite)) {
+			$fastestWrite = $row['write']['ms'];
+		}
 	}
-}
+	?>
+	<table class="table table-striped">
+		<thead>
+			<tr>
+				<th>Engine</th>
+				<th>Read (1000× ~100B)</th>
+				<th>Write (1000× ~100B)</th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php foreach ($results as $engine => $row) { ?>
+				<tr>
+					<td><strong><?php echo h($engine); ?></strong></td>
+					<?php foreach (['read', 'write'] as $op) { ?>
+						<?php
+						$cell = $row[$op] ?? null;
+						$isFastest = $op === 'read'
+							? (isset($cell['ms']) && $cell['ms'] === $fastestRead)
+							: (isset($cell['ms']) && $cell['ms'] === $fastestWrite);
+						?>
+						<td<?php echo $isFastest ? ' class="table-success"' : ''; ?>>
+							<?php if (isset($cell['error'])) { ?>
+								<span class="text-danger">error: <?php echo h($cell['error']); ?></span>
+							<?php } elseif (isset($cell['ms'])) { ?>
+								<?php echo h(number_format($cell['ms'], 2)); ?> ms
+								<br>
+								<small><?php echo h(number_format($cell['opsPerSec'], 0)); ?> ops/s</small>
+							<?php } else { ?>
+								&mdash;
+							<?php } ?>
+						</td>
+					<?php } ?>
+				</tr>
+			<?php } ?>
+		</tbody>
+	</table>
+
+	<p><small>
+		This is a single-pass micro-comparison on this host's current load. Take the absolute numbers with a pinch of salt; relative ordering is the useful signal.
+	</small></p>
+<?php } ?>
+
+<?php if ($unavailable) { ?>
+	<h3>Not available on this host</h3>
+	<ul>
+		<?php foreach ($unavailable as $engine => $entry) { ?>
+			<li>
+				<strong><?php echo h($engine); ?></strong>
+				<?php $shortName = App::shortName($entry['className'], 'Cache/Engine', 'Engine'); ?>
+				(<code><?php echo h($shortName); ?></code>)
+				&mdash; <?php echo h($entry['reason'] ?? ''); ?>
+			</li>
+		<?php } ?>
+	</ul>
+<?php } ?>
+
+</div>

--- a/tests/TestCase/Controller/Admin/BackendControllerTest.php
+++ b/tests/TestCase/Controller/Admin/BackendControllerTest.php
@@ -143,4 +143,31 @@ class BackendControllerTest extends TestCase {
 		$this->assertResponseCode(200);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testCacheBenchmarkGet() {
+		$this->disableErrorHandlerMiddleware();
+
+		$this->session(['Auth' => ['User' => ['id' => 1]]]);
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'Setup', 'controller' => 'Backend', 'action' => 'cacheBenchmark']);
+
+		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCacheBenchmarkPost() {
+		$this->disableErrorHandlerMiddleware();
+
+		$this->session(['Auth' => ['User' => ['id' => 1]]]);
+
+		$this->post(['prefix' => 'Admin', 'plugin' => 'Setup', 'controller' => 'Backend', 'action' => 'cacheBenchmark'], []);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('File');
+	}
+
 }

--- a/tests/TestCase/Utility/CacheBenchmarkTest.php
+++ b/tests/TestCase/Utility/CacheBenchmarkTest.php
@@ -85,4 +85,17 @@ class CacheBenchmarkTest extends TestCase {
 		$this->assertNotContains('_setup_benchmark_File', Cache::configured());
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testRunWithUnknownEngineReturnsErrorSentinel(): void {
+		$bench = new CacheBenchmark();
+		$results = $bench->run(['NotAnEngine']);
+
+		$this->assertArrayHasKey('NotAnEngine', $results);
+		$this->assertArrayHasKey('error', $results['NotAnEngine']['read']);
+		$this->assertArrayHasKey('error', $results['NotAnEngine']['write']);
+		$this->assertStringContainsString('Unknown cache engine', $results['NotAnEngine']['read']['error']);
+	}
+
 }

--- a/tests/TestCase/Utility/CacheBenchmarkTest.php
+++ b/tests/TestCase/Utility/CacheBenchmarkTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Setup\Test\TestCase\Utility;
 
+use Cake\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use Setup\Utility\CacheBenchmark;
 
@@ -50,6 +51,38 @@ class CacheBenchmarkTest extends TestCase {
 				$this->assertNotSame('', $entry['reason']);
 			}
 		}
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunFileEngineProducesReadAndWriteResults(): void {
+		$bench = new CacheBenchmark();
+		$results = $bench->run(['File']);
+
+		$this->assertArrayHasKey('File', $results);
+		$this->assertArrayHasKey('read', $results['File']);
+		$this->assertArrayHasKey('write', $results['File']);
+
+		$this->assertArrayHasKey('ms', $results['File']['read']);
+		$this->assertArrayHasKey('opsPerSec', $results['File']['read']);
+		$this->assertGreaterThan(0.0, $results['File']['read']['ms']);
+		$this->assertGreaterThan(0.0, $results['File']['read']['opsPerSec']);
+
+		$this->assertArrayHasKey('ms', $results['File']['write']);
+		$this->assertArrayHasKey('opsPerSec', $results['File']['write']);
+		$this->assertGreaterThan(0.0, $results['File']['write']['ms']);
+		$this->assertGreaterThan(0.0, $results['File']['write']['opsPerSec']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunDoesNotLeaveBehindBenchmarkConfigs(): void {
+		$bench = new CacheBenchmark();
+		$bench->run(['File']);
+
+		$this->assertNotContains('_setup_benchmark_File', Cache::configured());
 	}
 
 }

--- a/tests/TestCase/Utility/CacheBenchmarkTest.php
+++ b/tests/TestCase/Utility/CacheBenchmarkTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setup\Test\TestCase\Utility;
+
+use PHPUnit\Framework\TestCase;
+use Setup\Utility\CacheBenchmark;
+
+/**
+ * @uses \Setup\Utility\CacheBenchmark
+ */
+class CacheBenchmarkTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testAvailableEnginesIncludesFile(): void {
+		$bench = new CacheBenchmark();
+		$availability = $bench->availableEngines();
+
+		$this->assertArrayHasKey('File', $availability);
+		$this->assertTrue($availability['File']['available']);
+		$this->assertSame('Cake\Cache\Engine\FileEngine', $availability['File']['className']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAvailableEnginesReturnsAllExpectedEngineKeys(): void {
+		$bench = new CacheBenchmark();
+		$availability = $bench->availableEngines();
+
+		$this->assertSame(
+			['File', 'Apcu', 'Memcached', 'Redis', 'Wincache'],
+			array_keys($availability),
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUnavailableEngineHasReason(): void {
+		$bench = new CacheBenchmark();
+		$availability = $bench->availableEngines();
+
+		foreach ($availability as $entry) {
+			if (!$entry['available']) {
+				$this->assertArrayHasKey('reason', $entry);
+				$this->assertNotSame('', $entry['reason']);
+			}
+		}
+	}
+
+}

--- a/tests/TestCase/Utility/CacheBenchmarkTest.php
+++ b/tests/TestCase/Utility/CacheBenchmarkTest.php
@@ -32,7 +32,7 @@ class CacheBenchmarkTest extends TestCase {
 		$availability = $bench->availableEngines();
 
 		$this->assertSame(
-			['File', 'Apcu', 'Memcached', 'Redis', 'Wincache'],
+			['File', 'Apcu', 'Memcached', 'Redis'],
 			array_keys($availability),
 		);
 	}


### PR DESCRIPTION
## Summary

- Refactor `/admin/setup/backend/cache` from a `<ul>` of fat list items to a denser `<table>` layout with a banner link to the new benchmark page.
- New `/admin/setup/backend/cache-benchmark` page that benchmarks read/write performance across all CakePHP cache engines available on this host (File, Apcu, Memcached, Redis), with a side-by-side comparison table.
- New `Setup\Utility\CacheBenchmark` service class encapsulates engine availability probing and the benchmark sweep, keeping the controller thin.

## Method

For each engine, a throwaway `_setup_benchmark_<engine>` cache config is registered (with a `setup_benchmark_` prefix and an isolated path for File). Per engine:

1. Pre-populate 1000 small (~100B) values into a "read" keyspace (silent, not measured).
2. Time 1000 reads of those pre-populated keys.
3. Time 1000 writes into a separate "write" keyspace, so the read measurement is not tainted by warm engine state from a write loop.
4. Cleanup: `Cache::clear()` + `Cache::drop()` in a `finally` block.

Each engine's run is wrapped in try/catch — a failing engine surfaces as an error sentinel in its results row and the sweep continues. Engines whose PHP extension is missing (Apcu, Memcached, Redis on hosts that lack them) are silently omitted from the table and listed in a "Not available on this host" footer with the reason.

The fastest cell per column is highlighted via `table-success`. A caveat paragraph below the table makes clear this is a single-pass micro-comparison, not a scientific benchmark.

## Notes

- `Wincache` was deliberately omitted — `WincacheEngine` does not exist in CakePHP 5.
- `Array` and `Null` engines are excluded as well — not realistic for production use.
- The existing `cache()` action and its test are unchanged. View-vars contract preserved.
- Added 6 unit tests for `CacheBenchmark` (availability + run shape + cleanup + invalid engine handling) and 2 integration tests for the new controller action.