### PR TITLE
Fix three setup bugs: deprecated fetchModel, MySQL-only FK toggle, password in argv

### DIFF
--- a/src/Command/DbBackupCreateCommand.php
+++ b/src/Command/DbBackupCreateCommand.php
@@ -6,6 +6,7 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use RuntimeException;
 use Setup\Command\Traits\DbBackupTrait;
 use Setup\Command\Traits\DbToolsTrait;
 
@@ -28,6 +29,15 @@ class DbBackupCreateCommand extends Command {
 	protected Arguments $args;
 
 	protected ConsoleIo $io;
+
+	/**
+	 * Path to a temp .my.cnf-shaped credentials file passed to mysqldump via
+	 * --defaults-extra-file so the password is never visible in argv. Cleaned up
+	 * by {@see create()} in a finally block.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $credentialsFile = null;
 
 	/**
 	 * @return string
@@ -64,11 +74,18 @@ class DbBackupCreateCommand extends Command {
 
 		$file = $this->_path() . 'backup_' . date('Y-m-d--H-i-s');
 
+		// Don't interpolate the password into argv — `ps auxf` would surface it for
+		// any process on the box during the dump. Write it into a 0600 temp ini
+		// file and reference via --defaults-extra-file, then unlink in the finally
+		// block of create(). The username and host are not sensitive in the same
+		// way, but routing them through the same file keeps argv clean and the
+		// temp-file shape compatible with mysqldump's documented `[mysqldump]`
+		// section.
+		$this->credentialsFile = $this->writeCredentialsFile($config);
+
 		$optionStrings = [
-			'--user=' . escapeshellarg((string)($config['username'] ?? '')),
-			'--password=' . escapeshellarg((string)($config['password'] ?? '')),
+			'--defaults-extra-file=' . escapeshellarg($this->credentialsFile),
 			'--default-character-set=' . escapeshellarg((string)($config['encoding'] ?? 'utf8')),
-			'--host=' . escapeshellarg((string)($config['host'] ?? 'localhost')),
 			'--databases ' . escapeshellarg((string)$config['database']),
 			'--no-create-db',
 		];
@@ -133,14 +150,60 @@ class DbBackupCreateCommand extends Command {
 		if ($optionStrings) {
 			$command .= ' ' . implode(' ', $optionStrings);
 		}
-		if ($this->args->getOption('dry-run')) {
-			$this->io->out($command);
-			$ret = static::CODE_SUCCESS;
-		} else {
+
+		try {
+			if ($this->args->getOption('dry-run')) {
+				$this->io->out($command);
+
+				return true;
+			}
+
 			exec($command, $output, $ret);
+
+			return $ret === static::CODE_SUCCESS;
+		} finally {
+			// Always clean up the temp credentials file, even on a thrown exception
+			// from exec() or a forced abort. Leaving a 0600 cnf in /tmp is not
+			// terribly leaky, but the process owns it and should drop it.
+			if ($this->credentialsFile !== null && is_file($this->credentialsFile)) {
+				@unlink($this->credentialsFile);
+				$this->credentialsFile = null;
+			}
+		}
+	}
+
+	/**
+	 * Write a `[mysqldump]`-section credentials file to a 0600-perm temp path.
+	 *
+	 * Returns the file path; the caller is responsible for unlinking it after
+	 * the mysqldump invocation completes. Used in place of the previous
+	 * `--user=...` / `--password=...` argv interpolation, which exposed the
+	 * password to anyone able to read `ps`.
+	 *
+	 * @param array<string, mixed> $config Cake connection config (host, username, password).
+	 * @return string Absolute path to the written credentials file.
+	 */
+	protected function writeCredentialsFile(array $config): string {
+		$path = tempnam(sys_get_temp_dir(), 'cake-setup-mycnf-');
+		if ($path === false) {
+			throw new RuntimeException('Failed to create temp file for mysqldump credentials');
 		}
 
-		return $ret === static::CODE_SUCCESS;
+		$content = "[mysqldump]\n";
+		if (isset($config['username'])) {
+			$content .= 'user="' . addslashes((string)$config['username']) . "\"\n";
+		}
+		if (isset($config['password'])) {
+			$content .= 'password="' . addslashes((string)$config['password']) . "\"\n";
+		}
+		if (isset($config['host'])) {
+			$content .= 'host="' . addslashes((string)$config['host']) . "\"\n";
+		}
+
+		file_put_contents($path, $content);
+		chmod($path, 0600);
+
+		return $path;
 	}
 
 	/**

--- a/src/Command/DbWipeCommand.php
+++ b/src/Command/DbWipeCommand.php
@@ -6,6 +6,10 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlite;
+use Cake\Database\Driver\Sqlserver;
 use Setup\Command\Traits\DbToolsTrait;
 
 /**
@@ -46,15 +50,26 @@ class DbWipeCommand extends Command {
 		$schemaCollection = $db->getSchemaCollection();
 		$sources = $schemaCollection->listTables();
 
-		$tableTruncates = 'DROP TABLE ' . implode(';' . PHP_EOL . 'DROP TABLE ', $sources) . ';';
+		// FK-check disabling is driver-specific. The previous command emitted
+		// `SET FOREIGN_KEY_CHECKS` unconditionally, which is MySQL syntax and
+		// blows up on Postgres / SQLite / SQL Server. Map each driver to its
+		// equivalent off/on toggle.
+		$driver = $db->getDriver();
+		[$fkOff, $fkOn] = match (true) {
+			$driver instanceof Mysql => ['SET FOREIGN_KEY_CHECKS = 0;', 'SET FOREIGN_KEY_CHECKS = 1;'],
+			$driver instanceof Postgres => ["SET session_replication_role = 'replica';", "SET session_replication_role = 'origin';"],
+			$driver instanceof Sqlite => ['PRAGMA foreign_keys = OFF;', 'PRAGMA foreign_keys = ON;'],
+			$driver instanceof Sqlserver => ['EXEC sp_MSforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT ALL";', 'EXEC sp_MSforeachtable "ALTER TABLE ? CHECK CONSTRAINT ALL";'],
+			default => ['', ''],
+		};
 
-		$sql = <<<SQL
-SET FOREIGN_KEY_CHECKS = 0;
+		// On SQLite, prefer DROP TABLE IF EXISTS so a transient inconsistency
+		// (e.g. another connection already dropped a table) doesn't abort the
+		// whole wipe.
+		$dropPrefix = $driver instanceof Sqlite ? 'DROP TABLE IF EXISTS ' : 'DROP TABLE ';
+		$tableTruncates = $dropPrefix . implode(';' . PHP_EOL . $dropPrefix, $sources) . ';';
 
-$tableTruncates
-
-SET FOREIGN_KEY_CHECKS = 1;
-SQL;
+		$sql = trim(implode("\n\n", array_filter([$fkOff, $tableTruncates, $fkOn]))) . "\n";
 		$this->io->out('--------', 1, ConsoleIo::VERBOSE);
 		$this->io->out($sql, 1, ConsoleIo::VERBOSE);
 		$this->io->out('--------', 1, ConsoleIo::VERBOSE);

--- a/src/Command/UserCreateCommand.php
+++ b/src/Command/UserCreateCommand.php
@@ -9,7 +9,6 @@ use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
 use Cake\Database\Schema\TableSchemaInterface;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\Utility\Inflector;
 use Closure;
 
@@ -27,8 +26,6 @@ if (!defined('CLASS_USER')) {
  * @license MIT
  */
 class UserCreateCommand extends Command {
-
-	use ModelAwareTrait;
 
 	/**
 	 * @return string
@@ -49,7 +46,7 @@ class UserCreateCommand extends Command {
 		$password = $args->getArgument('password');
 
 		/** @var \App\Model\Table\UsersTable $Users */
-		$Users = $this->fetchModel(CLASS_USERS);
+		$Users = $this->fetchTable(CLASS_USERS);
 		$schema = $Users->getSchema();
 
 		$displayField = $Users->getDisplayField();

--- a/src/Command/UserUpdateCommand.php
+++ b/src/Command/UserUpdateCommand.php
@@ -6,7 +6,6 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Datasource\ModelAwareTrait;
 use Cake\Utility\Inflector;
 
 if (!defined('CLASS_USERS')) {
@@ -24,8 +23,6 @@ if (!defined('CLASS_USER')) {
  */
 class UserUpdateCommand extends Command {
 
-	use ModelAwareTrait;
-
 	/**
 	 * @return string
 	 */
@@ -42,7 +39,7 @@ class UserUpdateCommand extends Command {
 	 */
 	public function execute(Arguments $args, ConsoleIo $io) {
 		/** @var \App\Model\Table\UsersTable $Users */
-		$Users = $this->fetchModel(CLASS_USERS);
+		$Users = $this->fetchTable(CLASS_USERS);
 
 		$displayField = $Users->getDisplayField();
 		if (!is_string($displayField)) {


### PR DESCRIPTION
## Summary

Three correctness/security bugs from the source-grounded review:

- **`UserCreateCommand` / `UserUpdateCommand` used deprecated `ModelAwareTrait::fetchModel()`.** CakePHP 5.x deprecated `fetchModel()` in favor of `fetchTable()`. On a plugin pinned to `cakephp ^5.1.1` every fresh user creation tripped the deprecation warning. Dropped the trait and routed through `fetchTable()`.
- **`DbWipeCommand` emitted MySQL-only `SET FOREIGN_KEY_CHECKS = 0`.** On Postgres / SQLite / SQL Server the statement is a syntax error and the wipe aborted halfway, leaving the database half-dropped. Branched on the driver:
  - MySQL → `SET FOREIGN_KEY_CHECKS = 0/1`
  - Postgres → `SET session_replication_role = 'replica'/'origin'`
  - SQLite → `PRAGMA foreign_keys = OFF/ON`, plus `DROP TABLE IF EXISTS` so a transient inconsistency doesn't abort the whole wipe
  - SQL Server → `EXEC sp_MSforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT ALL"`
- **`DbBackupCreateCommand` exposed the DB password via argv.** Interpolating `--password=<secret>` into the exec'd command string makes the secret visible in `ps auxf` for any process on the host during the dump. Switched to the standard `--defaults-extra-file` pattern: write a `[mysqldump]`-section credentials file at a 0600-perm temp path, pass `--defaults-extra-file=<path>`, then unlink in a `finally` block so cleanup happens on both the happy path and the exception/abort branch.

phpunit (240/240), phpstan, and phpcs all clean.
