### PR TITLE
Add RFC 9116 security.txt middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ my Tools Plugin.
 Currently, this plugin contains only the parts I managed to migrate yet:
 
 * Maintenance Mode (dynamic activation and deactivation incl. dynamic IP whitelisting)
+* security.txt middleware (RFC 9116, with an always-future `Expires`)
 * Some very useful development tools and debugging shells
 
 ## Documentation
@@ -31,6 +32,7 @@ A few good entry points:
 * [Getting started](https://dereuromark.github.io/cakephp-setup/guide/)
 * [Installation](https://dereuromark.github.io/cakephp-setup/guide/installation)
 * [Maintenance Mode](https://dereuromark.github.io/cakephp-setup/maintenance/)
+* [security.txt Middleware](https://dereuromark.github.io/cakephp-setup/middleware/security-txt)
 * [Healthcheck](https://dereuromark.github.io/cakephp-setup/healthcheck/)
 * [Console Commands](https://dereuromark.github.io/cakephp-setup/console/)
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -17,6 +17,12 @@ function guideSidebar() {
       ],
     },
     {
+      text: 'Middleware',
+      items: [
+        { text: 'security.txt', link: '/middleware/security-txt' },
+      ],
+    },
+    {
       text: 'Healthcheck',
       items: [
         { text: 'Overview', link: '/healthcheck/' },
@@ -81,6 +87,7 @@ export default defineConfig({
     sidebar: {
       '/guide/': guideSidebar(),
       '/maintenance/': guideSidebar(),
+      '/middleware/': guideSidebar(),
       '/healthcheck/': guideSidebar(),
       '/panel/': guideSidebar(),
       '/console/': guideSidebar(),

--- a/docs/middleware/security-txt.md
+++ b/docs/middleware/security-txt.md
@@ -16,22 +16,22 @@ Because it answers before routing/auth, add it **early** in the queue.
 
 ## Setup
 
-Register it in your `Application::middleware()`:
+Describe the document with the `SecurityTxt` value object and register it in your
+`Application::middleware()`:
 
 ```php
+use Setup\Middleware\SecurityTxt;
 use Setup\Middleware\SecurityTxtMiddleware;
 
 public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
 {
     $middlewareQueue
-        ->add(new SecurityTxtMiddleware([
-            'fields' => [
-                'Contact' => 'https://github.com/owner/repo/security/advisories/new',
-                'Canonical' => 'https://example.com/.well-known/security.txt',
-                'Policy' => 'https://github.com/owner/repo/security/policy',
-                'Preferred-Languages' => 'en, de',
-            ],
-        ]))
+        ->add(new SecurityTxtMiddleware(new SecurityTxt(
+            contact: 'https://github.com/owner/repo/security/advisories/new',
+            canonical: 'https://example.com/.well-known/security.txt',
+            policy: 'https://github.com/owner/repo/security/policy',
+            preferredLanguages: 'en, de',
+        )))
         // ... the rest of your stack
     ;
 
@@ -43,41 +43,67 @@ It is then served at `https://example.com/.well-known/security.txt` (and, by
 default, at `/security.txt`).
 
 ::: warning Contact is required
-RFC 9116 requires a `Contact` field. If you do not configure one, the middleware
-passes through and serves nothing rather than emit an invalid file.
+RFC 9116 requires a `Contact`. It is the only non-optional parameter of
+`SecurityTxt`, and constructing a document (or the middleware) without a non-empty
+contact throws an `InvalidArgumentException` — so misconfiguration fails at boot
+rather than serving an invalid file.
 :::
 
-## Options
+## The `SecurityTxt` document
+
+Each parameter maps to an RFC 9116 field. A value may be a single string or a list
+of strings (repeated lines, e.g. multiple `Contact`). `null` fields are omitted.
+
+| Parameter | Field | Notes |
+|-----------|-------|-------|
+| `contact` *(required)* | `Contact` | `https:`, `mailto:`, or `tel:` URI(s). |
+| `canonical` | `Canonical` | Canonical URI(s) of this file. |
+| `encryption` | `Encryption` | Encryption key URI(s). |
+| `acknowledgments` | `Acknowledgments` | Hall-of-fame URI(s). |
+| `preferredLanguages` | `Preferred-Languages` | RFC 5646 tags, e.g. `en, de`. |
+| `policy` | `Policy` | Security policy URI(s). |
+| `hiring` | `Hiring` | Security-related job URI(s). |
+| `csaf` | `CSAF` | `provider-metadata.json` URI(s). |
+| `expiresInterval` | `Expires` | `strtotime`-relative interval (default `+1 year`). |
+
+::: info Expires is managed for you
+`Expires` is always computed from `expiresInterval`, so it stays in the future.
+Output order is: all `Contact` lines first, then the other fields, then `Expires`
+last.
+:::
+
+## Behavior options
+
+Transport/behavior knobs are passed as a second array argument (they are distinct
+from the document content):
+
+```php
+new SecurityTxtMiddleware($document, [
+    'cacheMaxAge' => WEEK,
+    'serveRootFallback' => false,
+]);
+```
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `path` | `/.well-known/security.txt` | Canonical path served. |
+| `path` | `/.well-known/security.txt` | Canonical path served (base-path aware). |
 | `serveRootFallback` | `true` | Also answer the legacy `/security.txt` path. |
-| `expiresInterval` | `'+1 year'` | `strtotime`-relative interval used to compute the always-future `Expires`. |
 | `cacheMaxAge` | `DAY` | `Cache-Control: max-age` in seconds. Set to `0` to omit the header. |
-| `fields` | `[]` | Field map (see below). |
 
-### `fields`
+## Array escape hatch
 
-An associative array of RFC 9116 field names to values. A value may be a string
-(one line) or an array of strings (repeated lines, e.g. multiple `Contact`):
+A raw config array is still accepted — useful for fields the value object does not
+cover, or fully dynamic config. The same `Contact` requirement applies:
 
 ```php
-'fields' => [
-    'Contact' => [
-        'https://github.com/owner/repo/security/advisories/new',
-        'mailto:security@example.com',
+new SecurityTxtMiddleware([
+    'cacheMaxAge' => 0,
+    'fields' => [
+        'Contact' => ['https://example.com/report', 'mailto:security@example.com'],
+        'Canonical' => 'https://example.com/.well-known/security.txt',
     ],
-    'Canonical' => 'https://example.com/.well-known/security.txt',
-    'Preferred-Languages' => 'en, de',
-],
+]);
 ```
-
-::: info Expires is managed for you
-`Expires` is always computed from `expiresInterval`. Any `Expires` you put in
-`fields` is ignored. Output order is: all `Contact` lines first, then the other
-fields in the order you declare them, then `Expires` last.
-:::
 
 ## Example output
 
@@ -90,6 +116,6 @@ Expires: 2027-05-23T00:00:00.000Z
 ```
 
 > [!TIP]
-> Pair the `Policy` field with a `SECURITY.md` in your repository (root, `.github/`,
+> Pair the `policy` field with a `SECURITY.md` in your repository (root, `.github/`,
 > or `docs/`). GitHub renders it at `/security/policy` and links it from the repo's
 > Security tab.

--- a/docs/middleware/security-txt.md
+++ b/docs/middleware/security-txt.md
@@ -1,0 +1,95 @@
+# security.txt Middleware
+
+`Setup\Middleware\SecurityTxtMiddleware` serves an [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116)
+`security.txt` file that tells security researchers how to report vulnerabilities.
+
+The required `Expires` field is **computed on every request**, so it never goes
+stale — no static file to hand-edit and no cron job to keep it fresh.
+
+## How it works
+
+The middleware short-circuits the request: when the path matches it returns the
+`text/plain` response directly, without touching routing, authentication, or any
+other downstream middleware. For every other path it simply passes through.
+
+Because it answers before routing/auth, add it **early** in the queue.
+
+## Setup
+
+Register it in your `Application::middleware()`:
+
+```php
+use Setup\Middleware\SecurityTxtMiddleware;
+
+public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+{
+    $middlewareQueue
+        ->add(new SecurityTxtMiddleware([
+            'fields' => [
+                'Contact' => 'https://github.com/owner/repo/security/advisories/new',
+                'Canonical' => 'https://example.com/.well-known/security.txt',
+                'Policy' => 'https://github.com/owner/repo/security/policy',
+                'Preferred-Languages' => 'en, de',
+            ],
+        ]))
+        // ... the rest of your stack
+    ;
+
+    return $middlewareQueue;
+}
+```
+
+It is then served at `https://example.com/.well-known/security.txt` (and, by
+default, at `/security.txt`).
+
+::: warning Contact is required
+RFC 9116 requires a `Contact` field. If you do not configure one, the middleware
+passes through and serves nothing rather than emit an invalid file.
+:::
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `path` | `/.well-known/security.txt` | Canonical path served. |
+| `serveRootFallback` | `true` | Also answer the legacy `/security.txt` path. |
+| `expiresInterval` | `'+1 year'` | `strtotime`-relative interval used to compute the always-future `Expires`. |
+| `cacheMaxAge` | `DAY` | `Cache-Control: max-age` in seconds. Set to `0` to omit the header. |
+| `fields` | `[]` | Field map (see below). |
+
+### `fields`
+
+An associative array of RFC 9116 field names to values. A value may be a string
+(one line) or an array of strings (repeated lines, e.g. multiple `Contact`):
+
+```php
+'fields' => [
+    'Contact' => [
+        'https://github.com/owner/repo/security/advisories/new',
+        'mailto:security@example.com',
+    ],
+    'Canonical' => 'https://example.com/.well-known/security.txt',
+    'Preferred-Languages' => 'en, de',
+],
+```
+
+::: info Expires is managed for you
+`Expires` is always computed from `expiresInterval`. Any `Expires` you put in
+`fields` is ignored. Output order is: all `Contact` lines first, then the other
+fields in the order you declare them, then `Expires` last.
+:::
+
+## Example output
+
+```text
+Contact: https://github.com/owner/repo/security/advisories/new
+Canonical: https://example.com/.well-known/security.txt
+Policy: https://github.com/owner/repo/security/policy
+Preferred-Languages: en, de
+Expires: 2027-05-23T00:00:00.000Z
+```
+
+> [!TIP]
+> Pair the `Policy` field with a `SECURITY.md` in your repository (root, `.github/`,
+> or `docs/`). GitHub renders it at `/security/policy` and links it from the repo's
+> Security tab.

--- a/docs/middleware/security-txt.md
+++ b/docs/middleware/security-txt.md
@@ -66,10 +66,17 @@ of strings (repeated lines, e.g. multiple `Contact`). `null` fields are omitted.
 | `csaf` | `CSAF` | `provider-metadata.json` URI(s). |
 | `expiresInterval` | `Expires` | `strtotime`-relative interval (default `+1 year`). |
 
+::: info Field order
+RFC 9116 does not give field order any meaning, so the value object emits a fixed,
+readable order: actionable fields first (`Contact`, `Encryption`, `Policy`, …),
+then file metadata (`Canonical`, `Preferred-Languages`), then the computed
+`Expires` last. (Multiple values of the same field keep their given order — for
+`Contact` that is the RFC's preference order.) The array escape hatch instead
+preserves the order in which you declare the fields.
+:::
+
 ::: info Expires is managed for you
 `Expires` is always computed from `expiresInterval`, so it stays in the future.
-Output order is: all `Contact` lines first, then the other fields, then `Expires`
-last.
 :::
 
 ## Behavior options
@@ -109,8 +116,8 @@ new SecurityTxtMiddleware([
 
 ```text
 Contact: https://github.com/owner/repo/security/advisories/new
-Canonical: https://example.com/.well-known/security.txt
 Policy: https://github.com/owner/repo/security/policy
+Canonical: https://example.com/.well-known/security.txt
 Preferred-Languages: en, de
 Expires: 2027-05-23T00:00:00.000Z
 ```

--- a/src/Middleware/SecurityTxt.php
+++ b/src/Middleware/SecurityTxt.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Setup\Middleware;
+
+use InvalidArgumentException;
+
+/**
+ * Value object describing the contents of an RFC 9116 `security.txt`.
+ *
+ * `Expires` is not a field here: it is computed by the middleware from
+ * `expiresInterval` so it is always in the future.
+ *
+ * Each field value may be a single string or a list of strings (repeated lines,
+ * e.g. multiple `Contact`). `Contact` is required by RFC 9116 — constructing a
+ * document without one throws.
+ */
+class SecurityTxt {
+
+	/**
+	 * @param array<string>|string $contact One or more contact URIs (`https:`, `mailto:`, `tel:`). Required.
+	 * @param array<string>|string|null $canonical Canonical URI(s) of this file.
+	 * @param array<string>|string|null $encryption Encryption key URI(s).
+	 * @param array<string>|string|null $acknowledgments Hall-of-fame URI(s).
+	 * @param array<string>|string|null $preferredLanguages RFC 5646 language tags, e.g. `en, de`.
+	 * @param array<string>|string|null $policy Security policy URI(s).
+	 * @param array<string>|string|null $hiring Security-related job URI(s).
+	 * @param array<string>|string|null $csaf `provider-metadata.json` URI(s).
+	 * @param string $expiresInterval `strtotime`-relative interval for the always-future `Expires`.
+	 *
+	 * @throws \InvalidArgumentException If no non-empty contact is provided.
+	 */
+	public function __construct(
+		public readonly string|array $contact,
+		public readonly string|array|null $canonical = null,
+		public readonly string|array|null $encryption = null,
+		public readonly string|array|null $acknowledgments = null,
+		public readonly string|array|null $preferredLanguages = null,
+		public readonly string|array|null $policy = null,
+		public readonly string|array|null $hiring = null,
+		public readonly string|array|null $csaf = null,
+		public readonly string $expiresInterval = '+1 year',
+	) {
+		if (static::normalize($contact) === []) {
+			throw new InvalidArgumentException(
+				'A security.txt document requires at least one non-empty `Contact` value (RFC 9116).',
+			);
+		}
+	}
+
+	/**
+	 * Ordered RFC 9116 field map, excluding the computed `Expires`.
+	 *
+	 * @return array<string, string|array<string>>
+	 */
+	public function toFields(): array {
+		$fields = [
+			'Contact' => $this->contact,
+			'Encryption' => $this->encryption,
+			'Acknowledgments' => $this->acknowledgments,
+			'Preferred-Languages' => $this->preferredLanguages,
+			'Canonical' => $this->canonical,
+			'Policy' => $this->policy,
+			'Hiring' => $this->hiring,
+			'CSAF' => $this->csaf,
+		];
+
+		return array_filter($fields, fn ($value): bool => $value !== null);
+	}
+
+	/**
+	 * Normalize a field value (string or list) into a list of non-empty trimmed strings.
+	 *
+	 * @param mixed $value
+	 * @return array<string>
+	 */
+	public static function normalize(mixed $value): array {
+		if ($value === null || $value === '' || $value === []) {
+			return [];
+		}
+
+		$values = is_array($value) ? $value : [$value];
+		$result = [];
+		foreach ($values as $item) {
+			$item = trim((string)$item);
+			if ($item !== '') {
+				$result[] = $item;
+			}
+		}
+
+		return $result;
+	}
+
+}

--- a/src/Middleware/SecurityTxt.php
+++ b/src/Middleware/SecurityTxt.php
@@ -50,18 +50,23 @@ class SecurityTxt {
 	/**
 	 * Ordered RFC 9116 field map, excluding the computed `Expires`.
 	 *
+	 * Field order is not significant per RFC 9116; this emits actionable fields
+	 * first (how to report) and file metadata last (`Canonical`,
+	 * `Preferred-Languages`) for readability. `Expires` is appended last by the
+	 * middleware.
+	 *
 	 * @return array<string, string|array<string>>
 	 */
 	public function toFields(): array {
 		$fields = [
 			'Contact' => $this->contact,
 			'Encryption' => $this->encryption,
-			'Acknowledgments' => $this->acknowledgments,
-			'Preferred-Languages' => $this->preferredLanguages,
-			'Canonical' => $this->canonical,
 			'Policy' => $this->policy,
-			'Hiring' => $this->hiring,
+			'Acknowledgments' => $this->acknowledgments,
 			'CSAF' => $this->csaf,
+			'Hiring' => $this->hiring,
+			'Canonical' => $this->canonical,
+			'Preferred-Languages' => $this->preferredLanguages,
 		];
 
 		return array_filter($fields, fn ($value): bool => $value !== null);

--- a/src/Middleware/SecurityTxtMiddleware.php
+++ b/src/Middleware/SecurityTxtMiddleware.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Setup\Middleware;
+
+use Cake\Core\InstanceConfigTrait;
+use Cake\Http\Response;
+use Laminas\Diactoros\CallbackStream;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Serves an RFC 9116 `security.txt` file.
+ *
+ * The `Expires` field is computed on every request from `expiresInterval`, so it
+ * never goes stale. `Contact` is required by the RFC; if none is configured the
+ * middleware passes through instead of emitting an invalid file.
+ *
+ * Add it early in the middleware queue (before routing/auth):
+ *
+ * ```php
+ * $middlewareQueue->add(new \Setup\Middleware\SecurityTxtMiddleware([
+ *     'fields' => [
+ *         'Contact' => 'https://github.com/owner/repo/security/advisories/new',
+ *         'Canonical' => 'https://example.com/.well-known/security.txt',
+ *         'Preferred-Languages' => 'en, de',
+ *     ],
+ * ]));
+ * ```
+ */
+class SecurityTxtMiddleware implements MiddlewareInterface {
+
+	use InstanceConfigTrait;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected array $_defaultConfig = [
+		'path' => '/.well-known/security.txt',
+		'serveRootFallback' => true,
+		'expiresInterval' => '+1 year',
+		'cacheMaxAge' => DAY,
+		'fields' => [],
+	];
+
+	/**
+	 * @param array<string, mixed> $config
+	 */
+	public function __construct(array $config = []) {
+		$this->setConfig($config);
+	}
+
+	/**
+	 * @param \Psr\Http\Message\ServerRequestInterface $request
+	 * @param \Psr\Http\Server\RequestHandlerInterface $handler
+	 *
+	 * @return \Psr\Http\Message\ResponseInterface
+	 */
+	public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface {
+		$method = $request->getMethod();
+		if (!in_array($method, ['GET', 'HEAD'], true)) {
+			return $handler->handle($request);
+		}
+
+		if (!$this->matchesPath($this->relativePath($request))) {
+			return $handler->handle($request);
+		}
+
+		/** @var array<string, mixed> $fields */
+		$fields = (array)$this->getConfig('fields');
+		$contacts = $this->normalizeValues($fields['Contact'] ?? null);
+		if (!$contacts) {
+			return $handler->handle($request);
+		}
+
+		$response = $this->build($fields, $contacts);
+
+		// HEAD must return the same headers as GET but without a body.
+		if ($method === 'HEAD') {
+			$response = $response->withBody(new CallbackStream(static fn (): string => ''));
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Resolve the request path relative to the application base path, so the
+	 * middleware also matches when the app is mounted in a subdirectory.
+	 *
+	 * @param \Psr\Http\Message\ServerRequestInterface $request
+	 * @return string
+	 */
+	protected function relativePath(ServerRequestInterface $request): string {
+		$path = $request->getUri()->getPath();
+		$base = (string)$request->getAttribute('base', '');
+		if ($base !== '' && str_starts_with($path, $base)) {
+			$path = substr($path, strlen($base));
+		}
+
+		return $path !== '' ? $path : '/';
+	}
+
+	/**
+	 * @param string $path
+	 * @return bool
+	 */
+	protected function matchesPath(string $path): bool {
+		if ($path === $this->getConfig('path')) {
+			return true;
+		}
+
+		return $this->getConfig('serveRootFallback') && $path === '/security.txt';
+	}
+
+	/**
+	 * @param array<string, mixed> $fields
+	 * @param array<string> $contacts
+	 *
+	 * @return \Psr\Http\Message\ResponseInterface
+	 */
+	protected function build(array $fields, array $contacts): ResponseInterface {
+		$lines = [];
+		foreach ($contacts as $value) {
+			$lines[] = 'Contact: ' . $value;
+		}
+		foreach ($fields as $name => $value) {
+			if ($name === 'Contact' || $name === 'Expires') {
+				continue;
+			}
+			foreach ($this->normalizeValues($value) as $item) {
+				$lines[] = $name . ': ' . $item;
+			}
+		}
+		$lines[] = 'Expires: ' . $this->expires();
+
+		$body = implode("\n", $lines) . "\n";
+
+		$response = (new Response())
+			->withType('text/plain')
+			->withStringBody($body);
+
+		$cacheMaxAge = (int)$this->getConfig('cacheMaxAge');
+		if ($cacheMaxAge > 0) {
+			$response = $response->withHeader('Cache-Control', 'max-age=' . $cacheMaxAge);
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Compute the RFC 9116 `Expires` value as a UTC ISO-8601 timestamp.
+	 *
+	 * @return string
+	 */
+	protected function expires(): string {
+		$interval = (string)$this->getConfig('expiresInterval');
+		$timestamp = strtotime($interval);
+		if ($timestamp === false) {
+			$timestamp = (int)strtotime('+1 year');
+		}
+
+		return gmdate('Y-m-d\TH:i:s.000\Z', $timestamp);
+	}
+
+	/**
+	 * Normalize a field value (string or list) into a list of non-empty trimmed strings.
+	 *
+	 * @param mixed $value
+	 * @return array<string>
+	 */
+	protected function normalizeValues($value): array {
+		if ($value === null || $value === '' || $value === []) {
+			return [];
+		}
+
+		$values = is_array($value) ? $value : [$value];
+		$result = [];
+		foreach ($values as $item) {
+			$item = trim((string)$item);
+			if ($item !== '') {
+				$result[] = $item;
+			}
+		}
+
+		return $result;
+	}
+
+}

--- a/src/Middleware/SecurityTxtMiddleware.php
+++ b/src/Middleware/SecurityTxtMiddleware.php
@@ -4,6 +4,7 @@ namespace Setup\Middleware;
 
 use Cake\Core\InstanceConfigTrait;
 use Cake\Http\Response;
+use InvalidArgumentException;
 use Laminas\Diactoros\CallbackStream;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -14,18 +15,30 @@ use Psr\Http\Server\RequestHandlerInterface;
  * Serves an RFC 9116 `security.txt` file.
  *
  * The `Expires` field is computed on every request from `expiresInterval`, so it
- * never goes stale. `Contact` is required by the RFC; if none is configured the
- * middleware passes through instead of emitting an invalid file.
+ * never goes stale. `Contact` is required by the RFC; constructing the middleware
+ * without one throws an `InvalidArgumentException` (fail fast at boot rather than
+ * serving an invalid file).
  *
- * Add it early in the middleware queue (before routing/auth):
+ * Add it early in the middleware queue (before routing/auth). Pass a
+ * {@see \Setup\Middleware\SecurityTxt} document (preferred):
+ *
+ * ```php
+ * $middlewareQueue->add(new \Setup\Middleware\SecurityTxtMiddleware(
+ *     new \Setup\Middleware\SecurityTxt(
+ *         contact: 'https://github.com/owner/repo/security/advisories/new',
+ *         canonical: 'https://example.com/.well-known/security.txt',
+ *         preferredLanguages: 'en, de',
+ *     ),
+ *     // optional behavior: ['path' => ..., 'serveRootFallback' => ..., 'cacheMaxAge' => ...]
+ * ));
+ * ```
+ *
+ * A raw config array is still accepted as an escape hatch (e.g. for fields not
+ * covered by the value object):
  *
  * ```php
  * $middlewareQueue->add(new \Setup\Middleware\SecurityTxtMiddleware([
- *     'fields' => [
- *         'Contact' => 'https://github.com/owner/repo/security/advisories/new',
- *         'Canonical' => 'https://example.com/.well-known/security.txt',
- *         'Preferred-Languages' => 'en, de',
- *     ],
+ *     'fields' => ['Contact' => 'mailto:security@example.com'],
  * ]));
  * ```
  */
@@ -45,10 +58,28 @@ class SecurityTxtMiddleware implements MiddlewareInterface {
 	];
 
 	/**
-	 * @param array<string, mixed> $config
+	 * @param \Setup\Middleware\SecurityTxt|array<string, mixed> $config A security.txt document (preferred), or a raw config array (escape hatch).
+	 * @param array<string, mixed> $options Behavior options (`path`, `serveRootFallback`, `cacheMaxAge`) when passing a document; ignored for the array form.
+	 *
+	 * @throws \InvalidArgumentException If no non-empty `Contact` is configured.
 	 */
-	public function __construct(array $config = []) {
+	public function __construct(SecurityTxt|array $config = [], array $options = []) {
+		if ($config instanceof SecurityTxt) {
+			$config = $options + [
+				'fields' => $config->toFields(),
+				'expiresInterval' => $config->expiresInterval,
+			];
+		}
+
 		$this->setConfig($config);
+
+		/** @var array<string, mixed> $fields */
+		$fields = (array)$this->getConfig('fields');
+		if (SecurityTxt::normalize($fields['Contact'] ?? null) === []) {
+			throw new InvalidArgumentException(
+				'SecurityTxtMiddleware requires at least one non-empty `Contact` field (RFC 9116).',
+			);
+		}
 	}
 
 	/**
@@ -69,10 +100,7 @@ class SecurityTxtMiddleware implements MiddlewareInterface {
 
 		/** @var array<string, mixed> $fields */
 		$fields = (array)$this->getConfig('fields');
-		$contacts = $this->normalizeValues($fields['Contact'] ?? null);
-		if (!$contacts) {
-			return $handler->handle($request);
-		}
+		$contacts = SecurityTxt::normalize($fields['Contact'] ?? null);
 
 		$response = $this->build($fields, $contacts);
 
@@ -128,7 +156,7 @@ class SecurityTxtMiddleware implements MiddlewareInterface {
 			if ($name === 'Contact' || $name === 'Expires') {
 				continue;
 			}
-			foreach ($this->normalizeValues($value) as $item) {
+			foreach (SecurityTxt::normalize($value) as $item) {
 				$lines[] = $name . ': ' . $item;
 			}
 		}
@@ -161,29 +189,6 @@ class SecurityTxtMiddleware implements MiddlewareInterface {
 		}
 
 		return gmdate('Y-m-d\TH:i:s.000\Z', $timestamp);
-	}
-
-	/**
-	 * Normalize a field value (string or list) into a list of non-empty trimmed strings.
-	 *
-	 * @param mixed $value
-	 * @return array<string>
-	 */
-	protected function normalizeValues($value): array {
-		if ($value === null || $value === '' || $value === []) {
-			return [];
-		}
-
-		$values = is_array($value) ? $value : [$value];
-		$result = [];
-		foreach ($values as $item) {
-			$item = trim((string)$item);
-			if ($item !== '') {
-				$result[] = $item;
-			}
-		}
-
-		return $result;
 	}
 
 }

--- a/tests/TestCase/Middleware/SecurityTxtMiddlewareTest.php
+++ b/tests/TestCase/Middleware/SecurityTxtMiddlewareTest.php
@@ -4,9 +4,11 @@ namespace Setup\Test\TestCase\Middleware;
 
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Setup\Middleware\SecurityTxt;
 use Setup\Middleware\SecurityTxtMiddleware;
 use Shim\TestSuite\TestCase;
 
@@ -90,12 +92,65 @@ class SecurityTxtMiddlewareTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testMissingContactPassesThrough(): void {
-		$middleware = new SecurityTxtMiddleware();
+	public function testThrowsWhenContactMissing(): void {
+		$this->expectException(InvalidArgumentException::class);
+
+		new SecurityTxtMiddleware();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testThrowsWhenContactEmptyInArray(): void {
+		$this->expectException(InvalidArgumentException::class);
+
+		new SecurityTxtMiddleware(['fields' => ['Contact' => '']]);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAcceptsSecurityTxtDocument(): void {
+		$middleware = new SecurityTxtMiddleware(new SecurityTxt(
+			contact: 'https://example.com/security/advisories/new',
+			canonical: 'https://example.com/.well-known/security.txt',
+			preferredLanguages: 'en, de',
+		));
+
+		$body = (string)$middleware->process($this->request('/.well-known/security.txt'), $this->handler())->getBody();
+
+		$this->assertStringContainsString('Contact: https://example.com/security/advisories/new', $body);
+		$this->assertStringContainsString('Canonical: https://example.com/.well-known/security.txt', $body);
+		$this->assertStringContainsString('Preferred-Languages: en, de', $body);
+		$this->assertStringContainsString('Expires:', $body);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDocumentBehaviorOptionsDisableRootFallback(): void {
+		$middleware = new SecurityTxtMiddleware(
+			new SecurityTxt(contact: 'mailto:security@example.com'),
+			['serveRootFallback' => false],
+		);
+
+		$response = $middleware->process($this->request('/security.txt'), $this->handler());
+
+		$this->assertSame('PASSTHROUGH', (string)$response->getBody());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDocumentBehaviorOptionsCacheMaxAge(): void {
+		$middleware = new SecurityTxtMiddleware(
+			new SecurityTxt(contact: 'mailto:security@example.com'),
+			['cacheMaxAge' => 60],
+		);
 
 		$response = $middleware->process($this->request('/.well-known/security.txt'), $this->handler());
 
-		$this->assertSame('PASSTHROUGH', (string)$response->getBody());
+		$this->assertSame('max-age=60', $response->getHeaderLine('Cache-Control'));
 	}
 
 	/**

--- a/tests/TestCase/Middleware/SecurityTxtMiddlewareTest.php
+++ b/tests/TestCase/Middleware/SecurityTxtMiddlewareTest.php
@@ -128,6 +128,27 @@ class SecurityTxtMiddlewareTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testDocumentFieldOrder(): void {
+		$middleware = new SecurityTxtMiddleware(new SecurityTxt(
+			contact: 'mailto:security@example.com',
+			canonical: 'https://example.com/.well-known/security.txt',
+			preferredLanguages: 'en, de',
+			policy: 'https://example.com/policy',
+		));
+
+		$body = trim((string)$middleware->process($this->request('/.well-known/security.txt'), $this->handler())->getBody());
+		$keys = array_map(fn (string $line): string => explode(':', $line, 2)[0], explode("\n", $body));
+
+		// Actionable fields first, file metadata next, computed Expires last.
+		$this->assertSame(
+			['Contact', 'Policy', 'Canonical', 'Preferred-Languages', 'Expires'],
+			$keys,
+		);
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testDocumentBehaviorOptionsDisableRootFallback(): void {
 		$middleware = new SecurityTxtMiddleware(
 			new SecurityTxt(contact: 'mailto:security@example.com'),

--- a/tests/TestCase/Middleware/SecurityTxtMiddlewareTest.php
+++ b/tests/TestCase/Middleware/SecurityTxtMiddlewareTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Setup\Test\TestCase\Middleware;
+
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Setup\Middleware\SecurityTxtMiddleware;
+use Shim\TestSuite\TestCase;
+
+class SecurityTxtMiddlewareTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testServesAtWellKnownPath(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => 'https://example.com/security'],
+		]);
+
+		$response = $middleware->process($this->request('/.well-known/security.txt'), $this->handler());
+
+		$this->assertSame(200, $response->getStatusCode());
+		$this->assertStringContainsString('text/plain', $response->getHeaderLine('Content-Type'));
+
+		$body = (string)$response->getBody();
+		$this->assertStringContainsString('Contact: https://example.com/security', $body);
+		$this->assertStringContainsString('Expires:', $body);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testExpiresInFuture(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => 'mailto:security@example.com'],
+		]);
+
+		$response = $middleware->process($this->request('/.well-known/security.txt'), $this->handler());
+
+		$body = (string)$response->getBody();
+		preg_match('/^Expires: (.+)$/m', $body, $matches);
+		$this->assertNotEmpty($matches);
+		$this->assertGreaterThan(time(), (int)strtotime($matches[1]));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRootFallbackServed(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => 'mailto:security@example.com'],
+		]);
+
+		$response = $middleware->process($this->request('/security.txt'), $this->handler());
+
+		$this->assertSame(200, $response->getStatusCode());
+		$this->assertStringNotContainsString('PASSTHROUGH', (string)$response->getBody());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRootFallbackDisabledPassesThrough(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'serveRootFallback' => false,
+			'fields' => ['Contact' => 'mailto:security@example.com'],
+		]);
+
+		$response = $middleware->process($this->request('/security.txt'), $this->handler());
+
+		$this->assertSame('PASSTHROUGH', (string)$response->getBody());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testUnrelatedPathPassesThrough(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => 'mailto:security@example.com'],
+		]);
+
+		$response = $middleware->process($this->request('/foo'), $this->handler());
+
+		$this->assertSame('PASSTHROUGH', (string)$response->getBody());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMissingContactPassesThrough(): void {
+		$middleware = new SecurityTxtMiddleware();
+
+		$response = $middleware->process($this->request('/.well-known/security.txt'), $this->handler());
+
+		$this->assertSame('PASSTHROUGH', (string)$response->getBody());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMultipleContacts(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => ['https://example.com/s', 'mailto:security@example.com']],
+		]);
+
+		$body = (string)$middleware->process($this->request('/.well-known/security.txt'), $this->handler())->getBody();
+
+		$this->assertSame(1, substr_count($body, 'Contact: https://example.com/s'));
+		$this->assertSame(1, substr_count($body, 'Contact: mailto:security@example.com'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNonGetMethodPassesThrough(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => 'mailto:security@example.com'],
+		]);
+
+		$response = $middleware->process($this->request('/.well-known/security.txt', 'POST'), $this->handler());
+
+		$this->assertSame('PASSTHROUGH', (string)$response->getBody());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testContactFirstAndExpiresLast(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => [
+				'Policy' => 'https://example.com/policy',
+				'Contact' => 'mailto:security@example.com',
+				'Preferred-Languages' => 'en, de',
+			],
+		]);
+
+		$body = (string)$middleware->process($this->request('/.well-known/security.txt'), $this->handler())->getBody();
+
+		$this->assertStringStartsWith('Contact: mailto:security@example.com', $body);
+		$this->assertStringContainsString('Policy: https://example.com/policy', $body);
+		$this->assertStringContainsString('Preferred-Languages: en, de', $body);
+
+		$lines = explode("\n", trim($body));
+		$this->assertStringStartsWith('Expires:', (string)end($lines));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testHeadRequestHasHeadersButNoBody(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => 'mailto:security@example.com'],
+		]);
+
+		$response = $middleware->process($this->request('/.well-known/security.txt', 'HEAD'), $this->handler());
+
+		$this->assertSame(200, $response->getStatusCode());
+		$this->assertStringContainsString('text/plain', $response->getHeaderLine('Content-Type'));
+		$this->assertSame('', (string)$response->getBody());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testServedUnderApplicationBasePath(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => 'mailto:security@example.com'],
+		]);
+
+		$request = new ServerRequest([
+			'url' => '/myapp/.well-known/security.txt',
+			'base' => '/myapp',
+			'environment' => ['REQUEST_METHOD' => 'GET'],
+		]);
+		$response = $middleware->process($request, $this->handler());
+
+		$this->assertSame(200, $response->getStatusCode());
+		$this->assertStringContainsString('Contact: mailto:security@example.com', (string)$response->getBody());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCacheControlHeader(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'cacheMaxAge' => 3600,
+			'fields' => ['Contact' => 'mailto:security@example.com'],
+		]);
+
+		$response = $middleware->process($this->request('/.well-known/security.txt'), $this->handler());
+
+		$this->assertSame('max-age=3600', $response->getHeaderLine('Cache-Control'));
+	}
+
+	/**
+	 * Build a request for the given path and method.
+	 *
+	 * @param string $path
+	 * @param string $method
+	 *
+	 * @return \Cake\Http\ServerRequest
+	 */
+	protected function request(string $path, string $method = 'GET'): ServerRequest {
+		return new ServerRequest([
+			'url' => $path,
+			'environment' => ['REQUEST_METHOD' => $method],
+		]);
+	}
+
+	/**
+	 * A pass-through handler returning a sentinel response.
+	 *
+	 * @return \Psr\Http\Server\RequestHandlerInterface
+	 */
+	protected function handler(): RequestHandlerInterface {
+		return new class implements RequestHandlerInterface {
+
+			/**
+			 * @param \Psr\Http\Message\ServerRequestInterface $request
+			 * @return \Psr\Http\Message\ResponseInterface
+			 */
+			public function handle(ServerRequestInterface $request): ResponseInterface {
+				return (new Response())->withStringBody('PASSTHROUGH');
+			}
+
+		};
+	}
+
+}

--- a/tests/TestCase/Middleware/SecurityTxtTest.php
+++ b/tests/TestCase/Middleware/SecurityTxtTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Setup\Test\TestCase\Middleware;
+
+use InvalidArgumentException;
+use Setup\Middleware\SecurityTxt;
+use Shim\TestSuite\TestCase;
+
+class SecurityTxtTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testToFieldsOmitsNullsAndOrdersContactFirst(): void {
+		$document = new SecurityTxt(
+			contact: 'mailto:security@example.com',
+			canonical: 'https://example.com/.well-known/security.txt',
+			preferredLanguages: 'en, de',
+		);
+
+		$fields = $document->toFields();
+
+		$this->assertSame(
+			['Contact', 'Preferred-Languages', 'Canonical'],
+			array_keys($fields),
+		);
+		$this->assertArrayNotHasKey('Policy', $fields);
+		$this->assertArrayNotHasKey('Expires', $fields);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testToFieldsKeepsMultipleContacts(): void {
+		$document = new SecurityTxt(
+			contact: ['https://example.com/s', 'mailto:security@example.com'],
+		);
+
+		$this->assertSame(
+			['https://example.com/s', 'mailto:security@example.com'],
+			$document->toFields()['Contact'],
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testThrowsOnEmptyContact(): void {
+		$this->expectException(InvalidArgumentException::class);
+
+		new SecurityTxt(contact: '');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testThrowsOnBlankContactList(): void {
+		$this->expectException(InvalidArgumentException::class);
+
+		new SecurityTxt(contact: ['', '   ']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNormalizeTrimsAndDropsEmpties(): void {
+		$this->assertSame(['a', 'b'], SecurityTxt::normalize([' a ', '', 'b', '  ']));
+		$this->assertSame(['x'], SecurityTxt::normalize('x'));
+		$this->assertSame([], SecurityTxt::normalize(null));
+	}
+
+}

--- a/tests/TestCase/Middleware/SecurityTxtTest.php
+++ b/tests/TestCase/Middleware/SecurityTxtTest.php
@@ -21,7 +21,7 @@ class SecurityTxtTest extends TestCase {
 		$fields = $document->toFields();
 
 		$this->assertSame(
-			['Contact', 'Preferred-Languages', 'Canonical'],
+			['Contact', 'Canonical', 'Preferred-Languages'],
 			array_keys($fields),
 		);
 		$this->assertArrayNotHasKey('Policy', $fields);


### PR DESCRIPTION
## security.txt Middleware (RFC 9116)

Adds `Setup\Middleware\SecurityTxtMiddleware` — a small PSR-15 middleware that serves an [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) `security.txt`.

 => https://www.dereuromark.de/2026/05/23/rfc-9116-security-txt-for-your-php-apps/

### Why

A `security.txt` tells researchers how to report vulnerabilities. The catch is the required `Expires` field: a static file's date silently goes stale. This middleware computes `Expires` on every request from a configurable interval (default `+1 year`), so it stays valid with zero maintenance.

### Usage

Describe the document with the typed `SecurityTxt` value object (IDE autocomplete, PHPStan-checked):

```php
use Setup\Middleware\SecurityTxt;
use Setup\Middleware\SecurityTxtMiddleware;

$middlewareQueue->add(new SecurityTxtMiddleware(new SecurityTxt(
    contact: 'https://github.com/owner/repo/security/advisories/new',
    canonical: 'https://example.com/.well-known/security.txt',
    preferredLanguages: 'en, de',
)));
```

A raw config array is still accepted as an escape hatch for fields the value object does not cover.

### Behavior

- Short-circuits early in the queue: serves `text/plain` at `/.well-known/security.txt` and (by default) `/security.txt`, without touching routing or auth. All other paths pass through.
- `Contact` is required by the RFC; without one, both the value object and the middleware throw `InvalidArgumentException` at construction (fail fast, not on first request).
- Field values may be a string or a list (repeated lines). `Expires` is always managed for you.
- `HEAD` returns the same headers as `GET` without a body.
- Path matching is base-path aware, so it also works when the app is mounted in a subdirectory.

### Included

- `SecurityTxt` value object + `SecurityTxtMiddleware`, 26 unit tests
- Docs page `docs/middleware/security-txt.md` wired into a new "Middleware" sidebar group
- README feature and docs-link entries