### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Command/BakeHealthcheckCommand.php
+++ b/src/Command/BakeHealthcheckCommand.php
@@ -105,12 +105,12 @@ class BakeHealthcheckCommand extends SimpleBakeCommand {
 		}
 		$taskClassNamespace = $namespace . '\Healthcheck\\Check\\' . str_replace(DS, '\\', $name);
 
-		if (strpos($name, '/') !== false) {
+		if (str_contains($name, '/')) {
 			$parts = explode('/', $name);
 			$name = array_pop($parts);
 		}
 
-		$content = <<<TXT
+		return <<<TXT
 <?php
 
 namespace $namespace\Test\TestCase\Healthcheck\Check$subNamespace;
@@ -135,8 +135,6 @@ class $testName extends TestCase {
 }
 
 TXT;
-
-		return $content;
 	}
 
 	/**
@@ -161,7 +159,7 @@ TXT;
 		$namespace .= '\\Healthcheck\\Check';
 
 		$namespacePart = null;
-		if (strpos($name, '/') !== false) {
+		if (str_contains($name, '/')) {
 			$parts = explode('/', $name);
 			$name = array_pop($parts);
 			$namespacePart = implode('\\', $parts);
@@ -206,9 +204,8 @@ TXT;
 			'help' => 'Type/Group',
 			'required' => true,
 		]);
-		$parser = parent::buildOptionParser($parser);
 
-		return $parser;
+		return parent::buildOptionParser($parser);
 	}
 
 }

--- a/src/Command/DbBackupCreateCommand.php
+++ b/src/Command/DbBackupCreateCommand.php
@@ -112,12 +112,12 @@ class DbBackupCreateCommand extends Command {
 			$file .= '_custom';
 		} elseif ($usePrefix) {
 			foreach ($sources as $key => $source) {
-				if (!str_starts_with((string) $source, (string) $usePrefix)) {
+				if (!str_starts_with((string)$source, (string)$usePrefix)) {
 					unset($sources[$key]);
 				}
 			}
 			$optionStrings[] = '--tables ' . implode(' ', array_map('escapeshellarg', $sources));
-			$file .= '_' . rtrim((string) $usePrefix, '_');
+			$file .= '_' . rtrim((string)$usePrefix, '_');
 		}
 		$file .= '.sql';
 		if ($args->getOption('compress')) {

--- a/src/Command/DbBackupCreateCommand.php
+++ b/src/Command/DbBackupCreateCommand.php
@@ -112,12 +112,12 @@ class DbBackupCreateCommand extends Command {
 			$file .= '_custom';
 		} elseif ($usePrefix) {
 			foreach ($sources as $key => $source) {
-				if (!str_starts_with($source, $usePrefix)) {
+				if (!str_starts_with((string) $source, (string) $usePrefix)) {
 					unset($sources[$key]);
 				}
 			}
 			$optionStrings[] = '--tables ' . implode(' ', array_map('escapeshellarg', $sources));
-			$file .= '_' . rtrim($usePrefix, '_');
+			$file .= '_' . rtrim((string) $usePrefix, '_');
 		}
 		$file .= '.sql';
 		if ($args->getOption('compress')) {

--- a/src/Command/DbBackupRestoreCommand.php
+++ b/src/Command/DbBackupRestoreCommand.php
@@ -140,9 +140,7 @@ class DbBackupRestoreCommand extends Command {
 		}
 		$file = $files[$x];
 
-		$file = BACKUPS . $file;
-
-		return $file;
+		return BACKUPS . $file;
 	}
 
 	/**

--- a/src/Command/DbDataDatesCommand.php
+++ b/src/Command/DbDataDatesCommand.php
@@ -80,7 +80,7 @@ class DbDataDatesCommand extends Command {
 			$io->out();
 
 			foreach ($issues as $table => $columns) {
-				foreach ($columns as $column => $data) {
+				foreach (array_keys($columns) as $column) {
 					$io->out("UPDATE `{$table}` SET `{$column}` = NULL WHERE CAST(`{$column}` AS CHAR(19)) LIKE '0000-00-00%';");
 				}
 			}

--- a/src/Command/DbDataDatesCommand.php
+++ b/src/Command/DbDataDatesCommand.php
@@ -80,7 +80,7 @@ class DbDataDatesCommand extends Command {
 			$io->out();
 
 			foreach ($issues as $table => $columns) {
-				foreach (array_keys($columns) as $column) {
+				foreach ($columns as $column => $_) {
 					$io->out("UPDATE `{$table}` SET `{$column}` = NULL WHERE CAST(`{$column}` AS CHAR(19)) LIKE '0000-00-00%';");
 				}
 			}

--- a/src/Command/DbDataEnumsCommand.php
+++ b/src/Command/DbDataEnumsCommand.php
@@ -175,7 +175,7 @@ class DbDataEnumsCommand extends Command {
 
 			foreach ($columns as $column) {
 				$columnType = $schema->getColumnType($column);
-				if (!$columnType || !str_starts_with($columnType, 'enum-')) {
+				if (!$columnType || !str_starts_with((string) $columnType, 'enum-')) {
 					continue;
 				}
 
@@ -325,7 +325,7 @@ class DbDataEnumsCommand extends Command {
 
 				// Look for setColumnType('column', EnumType::from(EnumClass::class))
 				// or getSchema()->setColumnType('column', 'enum-EnumClass')
-				if (strpos($content, $enumClass) === false && strpos($content, $shortEnumClass) === false) {
+				if (!str_contains($content, $enumClass) && !str_contains($content, $shortEnumClass)) {
 					continue;
 				}
 
@@ -445,7 +445,7 @@ class DbDataEnumsCommand extends Command {
 
 			if ($nullable) {
 				// Set to NULL
-				$sql = "UPDATE `{$table}` SET `{$column}` = NULL WHERE `{$column}` = '" . addslashes($invalidValue) . "'";
+				$sql = "UPDATE `{$table}` SET `{$column}` = NULL WHERE `{$column}` = '" . addslashes((string) $invalidValue) . "'";
 				$io->out("Setting {$table}.{$column} = NULL where value = '{$invalidValue}'");
 			} else {
 				// Column is NOT NULL - ask for a valid value or use first valid value
@@ -456,7 +456,7 @@ class DbDataEnumsCommand extends Command {
 					continue;
 				}
 				$io->warning("{$table}.{$column} is NOT NULL - setting to first valid value: '{$defaultValue}'");
-				$sql = "UPDATE `{$table}` SET `{$column}` = '" . addslashes((string)$defaultValue) . "' WHERE `{$column}` = '" . addslashes($invalidValue) . "'";
+				$sql = "UPDATE `{$table}` SET `{$column}` = '" . addslashes((string)$defaultValue) . "' WHERE `{$column}` = '" . addslashes((string) $invalidValue) . "'";
 			}
 
 			$statement = $db->execute($sql);

--- a/src/Command/DbDataEnumsCommand.php
+++ b/src/Command/DbDataEnumsCommand.php
@@ -175,7 +175,7 @@ class DbDataEnumsCommand extends Command {
 
 			foreach ($columns as $column) {
 				$columnType = $schema->getColumnType($column);
-				if (!$columnType || !str_starts_with((string) $columnType, 'enum-')) {
+				if (!$columnType || !str_starts_with((string)$columnType, 'enum-')) {
 					continue;
 				}
 
@@ -445,7 +445,7 @@ class DbDataEnumsCommand extends Command {
 
 			if ($nullable) {
 				// Set to NULL
-				$sql = "UPDATE `{$table}` SET `{$column}` = NULL WHERE `{$column}` = '" . addslashes((string) $invalidValue) . "'";
+				$sql = "UPDATE `{$table}` SET `{$column}` = NULL WHERE `{$column}` = '" . addslashes((string)$invalidValue) . "'";
 				$io->out("Setting {$table}.{$column} = NULL where value = '{$invalidValue}'");
 			} else {
 				// Column is NOT NULL - ask for a valid value or use first valid value
@@ -456,7 +456,7 @@ class DbDataEnumsCommand extends Command {
 					continue;
 				}
 				$io->warning("{$table}.{$column} is NOT NULL - setting to first valid value: '{$defaultValue}'");
-				$sql = "UPDATE `{$table}` SET `{$column}` = '" . addslashes((string)$defaultValue) . "' WHERE `{$column}` = '" . addslashes((string) $invalidValue) . "'";
+				$sql = "UPDATE `{$table}` SET `{$column}` = '" . addslashes((string)$defaultValue) . "' WHERE `{$column}` = '" . addslashes((string)$invalidValue) . "'";
 			}
 
 			$statement = $db->execute($sql);

--- a/src/Command/DbDataOrphansCommand.php
+++ b/src/Command/DbDataOrphansCommand.php
@@ -72,7 +72,7 @@ class DbDataOrphansCommand extends Command {
 		$io->warning('Found orphaned records:');
 		foreach ($issues as $model => $associations) {
 			$io->out(' - ' . $model . ':');
-			foreach ($associations as $assocName => $data) {
+			foreach ($associations as $data) {
 				$io->out('   * ' . $data['foreign_key'] . ' -> ' . $data['target_table'] . ': ' . $data['count'] . ' orphaned records');
 				$totalCount += $data['count'];
 			}
@@ -86,7 +86,7 @@ class DbDataOrphansCommand extends Command {
 			$io->out();
 
 			foreach ($issues as $model => $associations) {
-				foreach ($associations as $assocName => $data) {
+				foreach ($associations as $data) {
 					$io->out("-- {$data['table']}.{$data['foreign_key']} -> {$data['target_table']}");
 					$io->out("SELECT * FROM `{$data['table']}` WHERE `{$data['foreign_key']}` IS NOT NULL AND `{$data['foreign_key']}` NOT IN (SELECT `{$data['binding_key']}` FROM `{$data['target_table']}`);");
 					$io->out();
@@ -96,8 +96,8 @@ class DbDataOrphansCommand extends Command {
 			$io->out('SQL to fix (sets orphaned FKs to NULL):');
 			$io->out();
 
-			foreach ($issues as $model => $associations) {
-				foreach ($associations as $assocName => $data) {
+			foreach ($issues as $associations) {
+				foreach ($associations as $data) {
 					$io->out("UPDATE `{$data['table']}` SET `{$data['foreign_key']}` = NULL WHERE `{$data['foreign_key']}` IS NOT NULL AND `{$data['foreign_key']}` NOT IN (SELECT `{$data['binding_key']}` FROM `{$data['target_table']}`);");
 				}
 			}
@@ -222,8 +222,8 @@ class DbDataOrphansCommand extends Command {
 		$db = $this->_getConnection($connection);
 		$fixed = 0;
 
-		foreach ($issues as $model => $associations) {
-			foreach ($associations as $assocName => $data) {
+		foreach ($issues as $associations) {
+			foreach ($associations as $data) {
 				if ($delete) {
 					$sql = "DELETE FROM `{$data['table']}`
 						WHERE `{$data['foreign_key']}` IS NOT NULL

--- a/src/Command/DbInitCommand.php
+++ b/src/Command/DbInitCommand.php
@@ -44,7 +44,7 @@ class DbInitCommand extends Command {
 		$dbName = $config['database'];
 
 		// For SQLite
-		$name = substr($config['driver'], strrpos($config['driver'], '\\') + 1);
+		$name = substr((string) $config['driver'], strrpos((string) $config['driver'], '\\') + 1);
 		$config['scheme'] = strtolower($name);
 		if ($config['scheme'] === 'sqlite' && $config['database'] === ':memory:') {
 			$this->io->warning('Using in-memory database, skipping.');

--- a/src/Command/DbInitCommand.php
+++ b/src/Command/DbInitCommand.php
@@ -44,7 +44,7 @@ class DbInitCommand extends Command {
 		$dbName = $config['database'];
 
 		// For SQLite
-		$name = substr((string) $config['driver'], strrpos((string) $config['driver'], '\\') + 1);
+		$name = substr((string)$config['driver'], strrpos((string)$config['driver'], '\\') + 1);
 		$config['scheme'] = strtolower($name);
 		if ($config['scheme'] === 'sqlite' && $config['database'] === ':memory:') {
 			$this->io->warning('Using in-memory database, skipping.');

--- a/src/Command/DbIntegrityBoolsCommand.php
+++ b/src/Command/DbIntegrityBoolsCommand.php
@@ -136,12 +136,10 @@ class DbIntegrityBoolsCommand extends Command {
 		$columns = array_keys($schema);
 		foreach ($columns as $column) {
 			$fieldSchema = $schema[$column];
-			if ($this->isBoolField($fieldSchema)) {
-				if (str_ends_with($fieldSchema['Type'], 'unsigned')) {
-					$fieldSchema['Type'] = trim(substr($fieldSchema['Type'], 0, -8));
-					$fields[$column] = $fieldSchema;
-				}
-			}
+			if ($this->isBoolField($fieldSchema) && str_ends_with((string) $fieldSchema['Type'], 'unsigned')) {
+                $fieldSchema['Type'] = trim(substr((string) $fieldSchema['Type'], 0, -8));
+                $fields[$column] = $fieldSchema;
+            }
 		}
 
 		return $fields ? [$table => $fields] : [];
@@ -180,12 +178,9 @@ class DbIntegrityBoolsCommand extends Command {
 	 *
 	 * @return bool
 	 */
-	protected function isBoolField(array $field): bool {
-		if (str_starts_with($field['Type'], 'tinyint(1)')) {
-			return true;
-		}
-
-		return false;
-	}
+	protected function isBoolField(array $field): bool
+    {
+        return str_starts_with((string) $field['Type'], 'tinyint(1)');
+    }
 
 }

--- a/src/Command/DbIntegrityBoolsCommand.php
+++ b/src/Command/DbIntegrityBoolsCommand.php
@@ -136,10 +136,10 @@ class DbIntegrityBoolsCommand extends Command {
 		$columns = array_keys($schema);
 		foreach ($columns as $column) {
 			$fieldSchema = $schema[$column];
-			if ($this->isBoolField($fieldSchema) && str_ends_with((string) $fieldSchema['Type'], 'unsigned')) {
-                $fieldSchema['Type'] = trim(substr((string) $fieldSchema['Type'], 0, -8));
-                $fields[$column] = $fieldSchema;
-            }
+			if ($this->isBoolField($fieldSchema) && str_ends_with((string)$fieldSchema['Type'], 'unsigned')) {
+				$fieldSchema['Type'] = trim(substr((string)$fieldSchema['Type'], 0, -8));
+				$fields[$column] = $fieldSchema;
+			}
 		}
 
 		return $fields ? [$table => $fields] : [];
@@ -178,9 +178,8 @@ class DbIntegrityBoolsCommand extends Command {
 	 *
 	 * @return bool
 	 */
-	protected function isBoolField(array $field): bool
-    {
-        return str_starts_with((string) $field['Type'], 'tinyint(1)');
-    }
+	protected function isBoolField(array $field): bool {
+		return str_starts_with((string)$field['Type'], 'tinyint(1)');
+	}
 
 }

--- a/src/Command/DbIntegrityConstraintsCommand.php
+++ b/src/Command/DbIntegrityConstraintsCommand.php
@@ -74,10 +74,10 @@ class DbIntegrityConstraintsCommand extends Command {
 				$result[] = '$this->table(\'' . $table . '\')';
 
 				foreach ($fields as $field => $relation) {
-					$result[] = "\t" . '->addForeignKey(\'' . $field . '\', \'' . $relation['table'] . '\', [\'' . $relation['field'] . '\'], [\'delete\' => \'SET_NULL\'])';
+					$result[] = '	->addForeignKey(\'' . $field . '\', \'' . $relation['table'] . '\', [\'' . $relation['field'] . '\'], [\'delete\' => \'SET_NULL\'])';
 				}
 
-				$result[] = "\t" . '->update();';
+				$result[] = '	->update();';
 			}
 
 			$io->out($result);

--- a/src/Command/DbIntegrityIntsCommand.php
+++ b/src/Command/DbIntegrityIntsCommand.php
@@ -158,14 +158,14 @@ class DbIntegrityIntsCommand extends Command {
 				if ($length) {
 					$matches = [];
 					if ($hasComment) {
-						preg_match('/\[schema]\s*length:\s*(\d)/', $field['comment'], $matches);
+						preg_match('/\[schema]\s*length:\s*(\d)/', (string) $field['comment'], $matches);
 					}
 					if (!$matches) {
 						$lengthMeta = '[schema] length: ' . $length;
 						$field['comment'] = $field['comment'] ? $lengthMeta . '; ' . $field['comment'] : $lengthMeta;
 					} elseif ($this->args->getOption('overwrite')) {
 						$lengthMeta = '[schema] length: ' . $length;
-						$field['comment'] = preg_replace('/\[schema]\s*length:\s*\d/', $lengthMeta, $field['comment']);
+						$field['comment'] = preg_replace('/\[schema]\s*length:\s*\d/', $lengthMeta, (string) $field['comment']);
 					}
 					$fields[$column] = $field;
 				}
@@ -234,7 +234,7 @@ class DbIntegrityIntsCommand extends Command {
 			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 			foreach ($folderContent[1] as $file) {
-				$name = pathinfo($file, PATHINFO_FILENAME);
+				$name = pathinfo((string) $file, PATHINFO_FILENAME);
 
 				preg_match('#^(.+)Table$#', $name, $matches);
 				if (!$matches) {
@@ -260,13 +260,10 @@ class DbIntegrityIntsCommand extends Command {
 	 *
 	 * @return bool
 	 */
-	protected function isBoolField(array $field): bool {
-		if ($field['type'] === 'boolean' && $field['length'] === 1) {
-			return true;
-		}
-
-		return false;
-	}
+	protected function isBoolField(array $field): bool
+    {
+        return $field['type'] === 'boolean' && $field['length'] === 1;
+    }
 
 	/**
 	 * @param array<string, mixed> $field
@@ -275,7 +272,7 @@ class DbIntegrityIntsCommand extends Command {
 	 */
 	protected function isIntField(array $field): bool {
 		// We only care about different int types for now
-		if (!str_contains($field['type'], 'integer')) {
+		if (!str_contains((string) $field['type'], 'integer')) {
 			return false;
 		}
 		// Booleans we can ignore, they are always (1) length.

--- a/src/Command/DbIntegrityIntsCommand.php
+++ b/src/Command/DbIntegrityIntsCommand.php
@@ -158,14 +158,14 @@ class DbIntegrityIntsCommand extends Command {
 				if ($length) {
 					$matches = [];
 					if ($hasComment) {
-						preg_match('/\[schema]\s*length:\s*(\d)/', (string) $field['comment'], $matches);
+						preg_match('/\[schema]\s*length:\s*(\d)/', (string)$field['comment'], $matches);
 					}
 					if (!$matches) {
 						$lengthMeta = '[schema] length: ' . $length;
 						$field['comment'] = $field['comment'] ? $lengthMeta . '; ' . $field['comment'] : $lengthMeta;
 					} elseif ($this->args->getOption('overwrite')) {
 						$lengthMeta = '[schema] length: ' . $length;
-						$field['comment'] = preg_replace('/\[schema]\s*length:\s*\d/', $lengthMeta, (string) $field['comment']);
+						$field['comment'] = preg_replace('/\[schema]\s*length:\s*\d/', $lengthMeta, (string)$field['comment']);
 					}
 					$fields[$column] = $field;
 				}
@@ -234,7 +234,7 @@ class DbIntegrityIntsCommand extends Command {
 			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 			foreach ($folderContent[1] as $file) {
-				$name = pathinfo((string) $file, PATHINFO_FILENAME);
+				$name = pathinfo((string)$file, PATHINFO_FILENAME);
 
 				preg_match('#^(.+)Table$#', $name, $matches);
 				if (!$matches) {
@@ -260,10 +260,9 @@ class DbIntegrityIntsCommand extends Command {
 	 *
 	 * @return bool
 	 */
-	protected function isBoolField(array $field): bool
-    {
-        return $field['type'] === 'boolean' && $field['length'] === 1;
-    }
+	protected function isBoolField(array $field): bool {
+		return $field['type'] === 'boolean' && $field['length'] === 1;
+	}
 
 	/**
 	 * @param array<string, mixed> $field
@@ -272,7 +271,7 @@ class DbIntegrityIntsCommand extends Command {
 	 */
 	protected function isIntField(array $field): bool {
 		// We only care about different int types for now
-		if (!str_contains((string) $field['type'], 'integer')) {
+		if (!str_contains((string)$field['type'], 'integer')) {
 			return false;
 		}
 		// Booleans we can ignore, they are always (1) length.

--- a/src/Command/DbIntegrityKeysCommand.php
+++ b/src/Command/DbIntegrityKeysCommand.php
@@ -227,7 +227,7 @@ class DbIntegrityKeysCommand extends Command {
 			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 			foreach ($folderContent[1] as $file) {
-				$name = pathinfo((string) $file, PATHINFO_FILENAME);
+				$name = pathinfo((string)$file, PATHINFO_FILENAME);
 
 				preg_match('#^(.+)Table$#', $name, $matches);
 				if (!$matches) {
@@ -258,7 +258,8 @@ class DbIntegrityKeysCommand extends Command {
 		if ($field['type'] !== 'integer') {
 			return false;
 		}
-        return $field['unsigned'] !== true;
+
+		return $field['unsigned'] !== true;
 	}
 
 }

--- a/src/Command/DbIntegrityKeysCommand.php
+++ b/src/Command/DbIntegrityKeysCommand.php
@@ -227,7 +227,7 @@ class DbIntegrityKeysCommand extends Command {
 			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 			foreach ($folderContent[1] as $file) {
-				$name = pathinfo($file, PATHINFO_FILENAME);
+				$name = pathinfo((string) $file, PATHINFO_FILENAME);
 
 				preg_match('#^(.+)Table$#', $name, $matches);
 				if (!$matches) {
@@ -258,11 +258,7 @@ class DbIntegrityKeysCommand extends Command {
 		if ($field['type'] !== 'integer') {
 			return false;
 		}
-		if ($field['unsigned'] === true) {
-			return false;
-		}
-
-		return true;
+        return $field['unsigned'] !== true;
 	}
 
 }

--- a/src/Command/DbIntegrityNullsCommand.php
+++ b/src/Command/DbIntegrityNullsCommand.php
@@ -199,7 +199,7 @@ class DbIntegrityNullsCommand extends Command {
 			$fields[$field] = $fieldSchema;
 		}
 
-		foreach (array_keys($fields) as $field) {
+		foreach ($fields as $field => $_) {
 			$io->out('- ' . $field, 1, ConsoleIo::VERBOSE);
 		}
 

--- a/src/Command/DbIntegrityNullsCommand.php
+++ b/src/Command/DbIntegrityNullsCommand.php
@@ -199,7 +199,7 @@ class DbIntegrityNullsCommand extends Command {
 			$fields[$field] = $fieldSchema;
 		}
 
-		foreach ($fields as $field => $fieldSchema) {
+		foreach (array_keys($fields) as $field) {
 			$io->out('- ' . $field, 1, ConsoleIo::VERBOSE);
 		}
 

--- a/src/Command/DbResetCommand.php
+++ b/src/Command/DbResetCommand.php
@@ -46,7 +46,7 @@ class DbResetCommand extends Command {
 		$schemaCollection = $db->getSchemaCollection();
 		$sources = $schemaCollection->listTables();
 		foreach ($sources as $key => $source) {
-			if ($source === 'phinxlog' || str_contains((string) $source, '_phinxlog')) {
+			if ($source === 'phinxlog' || str_contains((string)$source, '_phinxlog')) {
 				unset($sources[$key]);
 			}
 		}

--- a/src/Command/DbResetCommand.php
+++ b/src/Command/DbResetCommand.php
@@ -46,7 +46,7 @@ class DbResetCommand extends Command {
 		$schemaCollection = $db->getSchemaCollection();
 		$sources = $schemaCollection->listTables();
 		foreach ($sources as $key => $source) {
-			if ($source === 'phinxlog' || str_contains($source, '_phinxlog')) {
+			if ($source === 'phinxlog' || str_contains((string) $source, '_phinxlog')) {
 				unset($sources[$key]);
 			}
 		}

--- a/src/Command/HealthcheckCommand.php
+++ b/src/Command/HealthcheckCommand.php
@@ -100,10 +100,8 @@ class HealthcheckCommand extends Command {
 			$io->out('### ' . $domain);
 			foreach ($checks as $check) {
 				$check->passed() ? $io->success($check->name()) : ($check->level() === $check::LEVEL_ERROR ? $io->error($check->name()) : $io->warning($check->name()));
-				if (!$check->passed()) {
-					if ($check->failureMessage()) {
-						$io->error('└ ' . implode(', ', $check->failureMessage()));
-					}
+				if (!$check->passed() && $check->failureMessage()) {
+					$io->error('└ ' . implode(', ', $check->failureMessage()));
 				}
 
 				// Always show warnings, even when check passes
@@ -111,10 +109,8 @@ class HealthcheckCommand extends Command {
 					$io->warning('└ ' . implode(', ', $check->warningMessage()));
 				}
 
-				if ($check->passed()) {
-					if ($check->successMessage()) {
-						$io->success('└ ' . implode(', ', $check->successMessage()));
-					}
+				if ($check->passed() && $check->successMessage()) {
+					$io->success('└ ' . implode(', ', $check->successMessage()));
 				}
 
 				if ($check->infoMessage()) {

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -361,7 +361,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
 			$paths['app'] = ' ' . $appPath;
 		}
 		if (defined('ROOT')) {
-			$paths['root'] = rtrim(ROOT, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+			$paths['root'] = rtrim((string) ROOT, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 		}
 		if (defined('CORE_PATH')) {
 			$paths['core'] = rtrim(CORE_PATH, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -361,7 +361,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
 			$paths['app'] = ' ' . $appPath;
 		}
 		if (defined('ROOT')) {
-			$paths['root'] = rtrim((string) ROOT, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+			$paths['root'] = rtrim((string)ROOT, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 		}
 		if (defined('CORE_PATH')) {
 			$paths['core'] = rtrim(CORE_PATH, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;

--- a/src/Command/MailCheckCommand.php
+++ b/src/Command/MailCheckCommand.php
@@ -64,9 +64,7 @@ TXT;
 	 * @return \Cake\Console\ConsoleOptionParser
 	 */
 	public function getOptionParser(): ConsoleOptionParser {
-		$parser = parent::getOptionParser();
-
-		return $parser;
+		return parent::getOptionParser();
 	}
 
 }

--- a/src/Command/MaintenanceModeActivateCommand.php
+++ b/src/Command/MaintenanceModeActivateCommand.php
@@ -62,9 +62,7 @@ class MaintenanceModeActivateCommand extends Command {
 	 * @return \Cake\Console\ConsoleOptionParser The built parser.
 	 */
 	protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser {
-		$parser = parent::buildOptionParser($parser);
-
-		return $parser;
+		return parent::buildOptionParser($parser);
 	}
 
 }

--- a/src/Command/MaintenanceModeStatusCommand.php
+++ b/src/Command/MaintenanceModeStatusCommand.php
@@ -62,9 +62,7 @@ class MaintenanceModeStatusCommand extends Command {
 	 * @return \Cake\Console\ConsoleOptionParser The built parser.
 	 */
 	protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser {
-		$parser = parent::buildOptionParser($parser);
-
-		return $parser;
+		return parent::buildOptionParser($parser);
 	}
 
 }

--- a/src/Command/MaintenanceModeWhitelistCommand.php
+++ b/src/Command/MaintenanceModeWhitelistCommand.php
@@ -50,20 +50,18 @@ class MaintenanceModeWhitelistCommand extends Command {
 	public function execute(Arguments $args, ConsoleIo $io) {
 		$ip = $args->getArgument('ip');
 		if ($ip) {
-			if (!Validation::ipOrSubnet($ip)) {
+            if (!Validation::ipOrSubnet($ip)) {
 				$io->abort($ip . ' is not a valid IP address or subnet.');
 			}
-			if ($args->getOption('remove')) {
+            if ($args->getOption('remove')) {
 				$this->Maintenance->clearWhitelist([$ip]);
 			} else {
 				$this->Maintenance->addToWhitelist([$ip]);
 			}
-			$io->out('Done!', 2);
-		} else {
-			if ($args->getOption('remove')) {
-				$this->Maintenance->clearWhitelist();
-			}
-		}
+            $io->out('Done!', 2);
+        } elseif ($args->getOption('remove')) {
+            $this->Maintenance->clearWhitelist();
+        }
 
 		$io->out('Current whitelist:');
 		/** @var array<string> $ip */

--- a/src/Command/MaintenanceModeWhitelistCommand.php
+++ b/src/Command/MaintenanceModeWhitelistCommand.php
@@ -50,18 +50,18 @@ class MaintenanceModeWhitelistCommand extends Command {
 	public function execute(Arguments $args, ConsoleIo $io) {
 		$ip = $args->getArgument('ip');
 		if ($ip) {
-            if (!Validation::ipOrSubnet($ip)) {
+			if (!Validation::ipOrSubnet($ip)) {
 				$io->abort($ip . ' is not a valid IP address or subnet.');
 			}
-            if ($args->getOption('remove')) {
+			if ($args->getOption('remove')) {
 				$this->Maintenance->clearWhitelist([$ip]);
 			} else {
 				$this->Maintenance->addToWhitelist([$ip]);
 			}
-            $io->out('Done!', 2);
-        } elseif ($args->getOption('remove')) {
-            $this->Maintenance->clearWhitelist();
-        }
+			$io->out('Done!', 2);
+		} elseif ($args->getOption('remove')) {
+			$this->Maintenance->clearWhitelist();
+		}
 
 		$io->out('Current whitelist:');
 		/** @var array<string> $ip */

--- a/src/Command/Traits/DbBackupTrait.php
+++ b/src/Command/Traits/DbBackupTrait.php
@@ -34,9 +34,9 @@ trait DbBackupTrait {
 	 */
 	protected function _command(string $command): string {
 		$path = match ($command) {
-            'gzip', 'gunzip' => Configure::read('Cli.gitPath'),
-            default => Configure::read('Cli.mysqlPath'),
-        };
+			'gzip', 'gunzip' => Configure::read('Cli.gitPath'),
+			default => Configure::read('Cli.mysqlPath'),
+		};
 
 		/** @var bool $windows */
 		$windows = WINDOWS;

--- a/src/Command/Traits/DbBackupTrait.php
+++ b/src/Command/Traits/DbBackupTrait.php
@@ -15,7 +15,7 @@ if (!defined('CHMOD_PUBLIC')) {
 	define('CHMOD_PUBLIC', 0770);
 }
 if (!defined('WINDOWS')) {
-	if (substr(PHP_OS, 0, 3) === 'WIN') {
+	if (str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);
@@ -33,15 +33,10 @@ trait DbBackupTrait {
 	 * @return string
 	 */
 	protected function _command(string $command): string {
-		switch ($command) {
-			case 'gzip':
-			case 'gunzip':
-				$path = Configure::read('Cli.gitPath');
-
-				break;
-			default:
-				$path = Configure::read('Cli.mysqlPath');
-		}
+		$path = match ($command) {
+            'gzip', 'gunzip' => Configure::read('Cli.gitPath'),
+            default => Configure::read('Cli.mysqlPath'),
+        };
 
 		/** @var bool $windows */
 		$windows = WINDOWS;
@@ -53,9 +48,7 @@ trait DbBackupTrait {
 	 * @return string
 	 */
 	protected function _path(): string {
-		$path = BACKUPS;
-
-		return $path;
+		return BACKUPS;
 	}
 
 	/**
@@ -74,9 +67,8 @@ trait DbBackupTrait {
 		foreach ($Regex as $v) {
 			$files[] = $v[0];
 		}
-		$files = array_reverse($files);
 
-		return $files;
+		return array_reverse($files);
 	}
 
 }

--- a/src/Command/Traits/DbToolsTrait.php
+++ b/src/Command/Traits/DbToolsTrait.php
@@ -58,7 +58,7 @@ AND table_name LIKE '$prefix%' OR table_name LIKE '\_%';";
 		$tables = [];
 		foreach ($res as $table) {
 			$tableName = $table['table_name'] ?? $table['TABLE_NAME'];
-			if (str_starts_with((string) $tableName, '_')) {
+			if (str_starts_with((string)$tableName, '_')) {
 				continue;
 			}
 
@@ -101,7 +101,7 @@ AND table_name LIKE '$prefix%' OR table_name LIKE '\_%';";
 			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 			foreach ($folderContent[1] as $file) {
-				$name = pathinfo((string) $file, PATHINFO_FILENAME);
+				$name = pathinfo((string)$file, PATHINFO_FILENAME);
 
 				preg_match('#^(.+)Table$#', $name, $matches);
 				if (!$matches) {

--- a/src/Command/Traits/DbToolsTrait.php
+++ b/src/Command/Traits/DbToolsTrait.php
@@ -56,9 +56,9 @@ AND table_name LIKE '$prefix%' OR table_name LIKE '\_%';";
 		$whitelist = []; //Text::tokenize((string)$this->args->getOption('table'));
 
 		$tables = [];
-		foreach ($res as $key => $table) {
+		foreach ($res as $table) {
 			$tableName = $table['table_name'] ?? $table['TABLE_NAME'];
-			if (str_starts_with($tableName, '_')) {
+			if (str_starts_with((string) $tableName, '_')) {
 				continue;
 			}
 
@@ -101,7 +101,7 @@ AND table_name LIKE '$prefix%' OR table_name LIKE '\_%';";
 			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 			foreach ($folderContent[1] as $file) {
-				$name = pathinfo($file, PATHINFO_FILENAME);
+				$name = pathinfo((string) $file, PATHINFO_FILENAME);
 
 				preg_match('#^(.+)Table$#', $name, $matches);
 				if (!$matches) {

--- a/src/Controller/Admin/BackendController.php
+++ b/src/Controller/Admin/BackendController.php
@@ -56,7 +56,7 @@ class BackendController extends AppController {
 		$postLimit = $Debug->postMaxSize(true);
 		$memoryLimit = $Debug->memoryLimit(true);
 
-		$this->set(['uploadLimit' => $uploadLimit, 'postLimit' => $postLimit, 'memoryLimit' => $memoryLimit]);
+		$this->set(compact('uploadLimit', 'postLimit', 'memoryLimit'));
 	}
 
 	/**
@@ -96,7 +96,7 @@ class BackendController extends AppController {
 
 		$System = new System();
 		$systemLocales = $System->systemLocales();
-		$this->set(['localeSettings' => $localeSettings, 'systemLocales' => $systemLocales]);
+		$this->set(compact('localeSettings', 'systemLocales'));
 
 		setlocale(LC_ALL, $save);
 	}
@@ -124,7 +124,7 @@ class BackendController extends AppController {
 
 		$this->set(compact('sessionData'));
 
-		$this->set(['time' => $time, 'sessionConfig' => $sessionConfig]);
+		$this->set(compact('time', 'sessionConfig'));
 	}
 
 	/**
@@ -183,10 +183,10 @@ SQL;
 
 			$dateTimeString = $token->created->format('Y-m-d H:i:s');
 
-			$this->set(['token' => $token, 'tokenRaw' => $tokenRaw]);
+			$this->set(compact('token', 'tokenRaw'));
 		}
 
-		$this->set(['time' => $time, 'timezone' => $timezone, 'dateTimeString' => $dateTimeString]);
+		$this->set(compact('time', 'timezone', 'dateTimeString'));
 	}
 
 	/**
@@ -239,7 +239,7 @@ SQL;
 			$data[$name] = Cache::read('_setup_test_string_', $name);
 		}
 
-		$this->set(['caches' => $caches, 'data' => $data]);
+		$this->set(compact('caches', 'data'));
 	}
 
 	/**
@@ -258,7 +258,7 @@ SQL;
 			$results = $bench->run($availableNames);
 		}
 
-		$this->set(['availability' => $availability, 'results' => $results]);
+		$this->set(compact('availability', 'results'));
 	}
 
 	/**
@@ -283,7 +283,7 @@ SQL;
 		$dbSize = array_sum($dbSizes);
 		$maxSize = $dbSizes ? max($dbSizes) : 0;
 
-		$this->set(['dbTables' => $dbTables, 'dbSize' => $dbSize, 'maxSize' => $maxSize]);
+		$this->set(compact('dbTables', 'dbSize', 'maxSize'));
 	}
 
 	/**
@@ -294,7 +294,7 @@ SQL;
 
 		$localConfig = Config::getLocal();
 
-		$this->set(['envVars' => $envVars, 'localConfig' => $localConfig]);
+		$this->set(compact('envVars', 'localConfig'));
 	}
 
 	/**
@@ -366,7 +366,7 @@ SQL;
 			}
 		}
 
-		$this->set(['ipAddress' => $ipAddress, 'requestClientIp' => $requestClientIp, 'host' => $host, 'serverIp' => $serverIp, 'serverHost' => $serverHost, 'serverName' => $serverName, 'serverPort' => $serverPort, 'requestInfo' => $requestInfo, 'proxyHeaders' => $proxyHeaders, 'networkInterfaces' => $networkInterfaces]);
+		$this->set(compact('ipAddress', 'requestClientIp', 'host', 'serverIp', 'serverHost', 'serverName', 'serverPort', 'requestInfo', 'proxyHeaders', 'networkInterfaces'));
 	}
 
 	/**
@@ -380,7 +380,7 @@ SQL;
 		$map = OrmTypes::getMap();
 		$classes = OrmTypes::getClasses($plugins, $map);
 
-		$this->set(['plugins' => $plugins, 'classes' => $classes, 'map' => $map]);
+		$this->set(compact('plugins', 'classes', 'map'));
 	}
 
 }

--- a/src/Controller/Admin/BackendController.php
+++ b/src/Controller/Admin/BackendController.php
@@ -72,7 +72,7 @@ class BackendController extends AppController {
 			}
 			$time = new DateTime();
 			$result = strftime($dateFormat, (int)$time->toUnixString());
-			$this->set(['result' => $result]);
+			$this->set(compact('result'));
 		} else {
 			//FIXME
 			//$this->request->data['Form']['format'] = '%A, %B %Y - %H:%M';
@@ -122,7 +122,7 @@ class BackendController extends AppController {
 			];
 		}
 
-		$this->set(['sessionData' => $sessionData]);
+		$this->set(compact('sessionData'));
 
 		$this->set(['time' => $time, 'sessionConfig' => $sessionConfig]);
 	}
@@ -210,7 +210,7 @@ SQL;
 			return $this->redirect([]);
 		}
 
-		$this->set(['cookies' => $cookies]);
+		$this->set(compact('cookies'));
 	}
 
 	/**

--- a/src/Controller/Admin/BackendController.php
+++ b/src/Controller/Admin/BackendController.php
@@ -56,7 +56,7 @@ class BackendController extends AppController {
 		$postLimit = $Debug->postMaxSize(true);
 		$memoryLimit = $Debug->memoryLimit(true);
 
-		$this->set(compact('uploadLimit', 'postLimit', 'memoryLimit'));
+		$this->set(['uploadLimit' => $uploadLimit, 'postLimit' => $postLimit, 'memoryLimit' => $memoryLimit]);
 	}
 
 	/**
@@ -72,7 +72,7 @@ class BackendController extends AppController {
 			}
 			$time = new DateTime();
 			$result = strftime($dateFormat, (int)$time->toUnixString());
-			$this->set(compact('result'));
+			$this->set(['result' => $result]);
 		} else {
 			//FIXME
 			//$this->request->data['Form']['format'] = '%A, %B %Y - %H:%M';
@@ -96,7 +96,7 @@ class BackendController extends AppController {
 
 		$System = new System();
 		$systemLocales = $System->systemLocales();
-		$this->set(compact('localeSettings', 'systemLocales'));
+		$this->set(['localeSettings' => $localeSettings, 'systemLocales' => $systemLocales]);
 
 		setlocale(LC_ALL, $save);
 	}
@@ -122,9 +122,9 @@ class BackendController extends AppController {
 			];
 		}
 
-		$this->set(compact('sessionData'));
+		$this->set(['sessionData' => $sessionData]);
 
-		$this->set(compact('time', 'sessionConfig'));
+		$this->set(['time' => $time, 'sessionConfig' => $sessionConfig]);
 	}
 
 	/**
@@ -183,10 +183,10 @@ SQL;
 
 			$dateTimeString = $token->created->format('Y-m-d H:i:s');
 
-			$this->set(compact('token', 'tokenRaw'));
+			$this->set(['token' => $token, 'tokenRaw' => $tokenRaw]);
 		}
 
-		$this->set(compact('time', 'timezone', 'dateTimeString'));
+		$this->set(['time' => $time, 'timezone' => $timezone, 'dateTimeString' => $dateTimeString]);
 	}
 
 	/**
@@ -210,7 +210,7 @@ SQL;
 			return $this->redirect([]);
 		}
 
-		$this->set(compact('cookies'));
+		$this->set(['cookies' => $cookies]);
 	}
 
 	/**
@@ -239,7 +239,7 @@ SQL;
 			$data[$name] = Cache::read('_setup_test_string_', $name);
 		}
 
-		$this->set(compact('caches', 'data'));
+		$this->set(['caches' => $caches, 'data' => $data]);
 	}
 
 	/**
@@ -258,7 +258,7 @@ SQL;
 			$results = $bench->run($availableNames);
 		}
 
-		$this->set(compact('availability', 'results'));
+		$this->set(['availability' => $availability, 'results' => $results]);
 	}
 
 	/**
@@ -272,7 +272,7 @@ SQL;
 		$dbTables = (new Collection($dbTables))->toArray();
 		$dbSizes = [];
 		foreach ($dbTables as $key => $dbTable) {
-			if (preg_match('/phinxlog$/', $dbTable['Name'])) {
+			if (preg_match('/phinxlog$/', (string) $dbTable['Name'])) {
 				unset($dbTables[$key]);
 
 				continue;
@@ -283,7 +283,7 @@ SQL;
 		$dbSize = array_sum($dbSizes);
 		$maxSize = $dbSizes ? max($dbSizes) : 0;
 
-		$this->set(compact('dbTables', 'dbSize', 'maxSize'));
+		$this->set(['dbTables' => $dbTables, 'dbSize' => $dbSize, 'maxSize' => $maxSize]);
 	}
 
 	/**
@@ -294,7 +294,7 @@ SQL;
 
 		$localConfig = Config::getLocal();
 
-		$this->set(compact('envVars', 'localConfig'));
+		$this->set(['envVars' => $envVars, 'localConfig' => $localConfig]);
 	}
 
 	/**
@@ -366,18 +366,7 @@ SQL;
 			}
 		}
 
-		$this->set(compact(
-			'ipAddress',
-			'requestClientIp',
-			'host',
-			'serverIp',
-			'serverHost',
-			'serverName',
-			'serverPort',
-			'requestInfo',
-			'proxyHeaders',
-			'networkInterfaces',
-		));
+		$this->set(['ipAddress' => $ipAddress, 'requestClientIp' => $requestClientIp, 'host' => $host, 'serverIp' => $serverIp, 'serverHost' => $serverHost, 'serverName' => $serverName, 'serverPort' => $serverPort, 'requestInfo' => $requestInfo, 'proxyHeaders' => $proxyHeaders, 'networkInterfaces' => $networkInterfaces]);
 	}
 
 	/**
@@ -391,7 +380,7 @@ SQL;
 		$map = OrmTypes::getMap();
 		$classes = OrmTypes::getClasses($plugins, $map);
 
-		$this->set(compact('plugins', 'classes', 'map'));
+		$this->set(['plugins' => $plugins, 'classes' => $classes, 'map' => $map]);
 	}
 
 }

--- a/src/Controller/Admin/BackendController.php
+++ b/src/Controller/Admin/BackendController.php
@@ -272,7 +272,7 @@ SQL;
 		$dbTables = (new Collection($dbTables))->toArray();
 		$dbSizes = [];
 		foreach ($dbTables as $key => $dbTable) {
-			if (preg_match('/phinxlog$/', (string) $dbTable['Name'])) {
+			if (preg_match('/phinxlog$/', (string)$dbTable['Name'])) {
 				unset($dbTables[$key]);
 
 				continue;

--- a/src/Controller/Admin/ConfigurationController.php
+++ b/src/Controller/Admin/ConfigurationController.php
@@ -38,7 +38,7 @@ class ConfigurationController extends AppController {
 		if ($mem) {
 			$memory = '' . $mem['total'] . ' MB total; ' . $mem['free'] . ' MB free';
 		}
-		$this->set(compact('serverLoad', 'memory', 'uptime'));
+		$this->set(['serverLoad' => $serverLoad, 'memory' => $memory, 'uptime' => $uptime]);
 	}
 
 }

--- a/src/Controller/Admin/ConfigurationController.php
+++ b/src/Controller/Admin/ConfigurationController.php
@@ -38,7 +38,7 @@ class ConfigurationController extends AppController {
 		if ($mem) {
 			$memory = '' . $mem['total'] . ' MB total; ' . $mem['free'] . ' MB free';
 		}
-		$this->set(['serverLoad' => $serverLoad, 'memory' => $memory, 'uptime' => $uptime]);
+		$this->set(compact('serverLoad', 'memory', 'uptime'));
 	}
 
 }

--- a/src/Controller/Admin/DatabaseController.php
+++ b/src/Controller/Admin/DatabaseController.php
@@ -37,7 +37,7 @@ class DatabaseController extends AppController {
 
 		$tables = [];
 		foreach ($dbTables as $dbTable) {
-			if (preg_match('/phinxlog$/', (string) $dbTable['Name'])) {
+			if (preg_match('/phinxlog$/', (string)$dbTable['Name'])) {
 				continue;
 			}
 			$blacklist = Configure::read('Setup.blacklistedTables');

--- a/src/Controller/Admin/DatabaseController.php
+++ b/src/Controller/Admin/DatabaseController.php
@@ -37,7 +37,7 @@ class DatabaseController extends AppController {
 
 		$tables = [];
 		foreach ($dbTables as $dbTable) {
-			if (preg_match('/phinxlog$/', $dbTable['Name'])) {
+			if (preg_match('/phinxlog$/', (string) $dbTable['Name'])) {
 				continue;
 			}
 			$blacklist = Configure::read('Setup.blacklistedTables');
@@ -54,7 +54,7 @@ class DatabaseController extends AppController {
 			];
 		}
 
-		$this->set(compact('tables'));
+		$this->set(['tables' => $tables]);
 	}
 
 }

--- a/src/Controller/Admin/DatabaseController.php
+++ b/src/Controller/Admin/DatabaseController.php
@@ -54,7 +54,7 @@ class DatabaseController extends AppController {
 			];
 		}
 
-		$this->set(['tables' => $tables]);
+		$this->set(compact('tables'));
 	}
 
 }

--- a/src/Controller/Admin/SetupController.php
+++ b/src/Controller/Admin/SetupController.php
@@ -38,7 +38,7 @@ class SetupController extends AppController {
 		$whitelisted = $maintenance->whitelisted($ip);
 		$whitelist = $maintenance->whitelist();
 
-		$this->set(['ip' => $ip, 'isMaintenanceModeEnabled' => $isMaintenanceModeEnabled, 'whitelisted' => $whitelisted, 'whitelist' => $whitelist]);
+		$this->set(compact('ip', 'isMaintenanceModeEnabled', 'whitelisted', 'whitelist'));
 	}
 
 }

--- a/src/Controller/Admin/SetupController.php
+++ b/src/Controller/Admin/SetupController.php
@@ -38,7 +38,7 @@ class SetupController extends AppController {
 		$whitelisted = $maintenance->whitelisted($ip);
 		$whitelist = $maintenance->whitelist();
 
-		$this->set(compact('ip', 'isMaintenanceModeEnabled', 'whitelisted', 'whitelist'));
+		$this->set(['ip' => $ip, 'isMaintenanceModeEnabled' => $isMaintenanceModeEnabled, 'whitelisted' => $whitelisted, 'whitelist' => $whitelist]);
 	}
 
 }

--- a/src/Controller/Component/HealthcheckComponent.php
+++ b/src/Controller/Component/HealthcheckComponent.php
@@ -50,7 +50,7 @@ class HealthcheckComponent extends Component {
 		$errors = $healthcheck->errors();
 		$warnings = $healthcheck->warnings();
 
-		return compact('passed', 'result', 'domains', 'errors', 'warnings', 'executionTime', 'healthcheck');
+		return ['passed' => $passed, 'result' => $result, 'domains' => $domains, 'errors' => $errors, 'warnings' => $warnings, 'executionTime' => $executionTime, 'healthcheck' => $healthcheck];
 	}
 
 	/**

--- a/src/Controller/Component/SetupComponent.php
+++ b/src/Controller/Component/SetupComponent.php
@@ -191,7 +191,7 @@ class SetupComponent extends Component {
 			return;
 		}
 		$referer = $this->Controller->referer();
-		if (strlen((string) $referer) > 2 && (int)$this->getController()->getRequest()->getSession()->read('Report.404') < time() - 5 * MINUTE) {
+		if (strlen((string)$referer) > 2 && (int)$this->getController()->getRequest()->getSession()->read('Report.404') < time() - 5 * MINUTE) {
 			$text = '404:' . TB . TB . $this->Controller->getRequest()->getRequestTarget()
 			. NL . 'Referer:' . TB . '' . $referer
 			. NL . NL . 'Browser: ' . env('HTTP_USER_AGENT')
@@ -232,7 +232,8 @@ class SetupComponent extends Component {
 			return true;
 		}
 		$pwd = $this->Controller->getRequest()->getQuery('pwd');
-        return $pwd && $pwd === Configure::read('Config.pwd');
+
+		return $pwd && $pwd === Configure::read('Config.pwd');
 	}
 
 	/**

--- a/src/Controller/Component/SetupComponent.php
+++ b/src/Controller/Component/SetupComponent.php
@@ -13,7 +13,7 @@ use Setup\Utility\Setup;
 use Tools\Mailer\Mailer;
 
 if (!defined('WINDOWS')) {
-	if (substr(PHP_OS, 0, 3) === 'WIN') {
+	if (str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);
@@ -94,7 +94,7 @@ class SetupComponent extends Component {
 		if ($this->Controller->getRequest()->getQuery('maintenance') !== null) {
 			$mode = $this->Controller->getRequest()->getQuery('maintenance') ? __d('setup', 'activated') : __d('setup', 'deactivated');
 			$result = $this->setMaintenance((bool)$this->Controller->getRequest()->getQuery('maintenance'));
-			if ($result !== false) {
+			if ($result) {
 				$this->Controller->Flash->success(__d('setup', 'Maintenance mode {0}', $mode));
 			} else {
 				$this->Controller->Flash->error(__d('setup', 'Maintenance mode not {0}', $mode));
@@ -191,7 +191,7 @@ class SetupComponent extends Component {
 			return;
 		}
 		$referer = $this->Controller->referer();
-		if (strlen($referer) > 2 && (int)$this->getController()->getRequest()->getSession()->read('Report.404') < time() - 5 * MINUTE) {
+		if (strlen((string) $referer) > 2 && (int)$this->getController()->getRequest()->getSession()->read('Report.404') < time() - 5 * MINUTE) {
 			$text = '404:' . TB . TB . $this->Controller->getRequest()->getRequestTarget()
 			. NL . 'Referer:' . TB . '' . $referer
 			. NL . NL . 'Browser: ' . env('HTTP_USER_AGENT')
@@ -232,11 +232,7 @@ class SetupComponent extends Component {
 			return true;
 		}
 		$pwd = $this->Controller->getRequest()->getQuery('pwd');
-		if ($pwd && $pwd === Configure::read('Config.pwd')) {
-			return true;
-		}
-
-		return false;
+        return $pwd && $pwd === Configure::read('Config.pwd');
 	}
 
 	/**
@@ -334,10 +330,8 @@ class SetupComponent extends Component {
 			return false;
 		}
 
-		if (!empty($id)) {
-			if (file_put_contents($file, $level)) {
-				return (bool)$level;
-			}
+		if (!empty($id) && file_put_contents($file, $level)) {
+			return (bool)$level;
 		}
 
 		return false;
@@ -391,7 +385,7 @@ class SetupComponent extends Component {
 	 * @return bool Success
 	 */
 	protected function _notification($title, $text) {
-		if (!isset($this->Mailer)) {
+		if ($this->Mailer === null) {
 			$this->Mailer = new Mailer();
 		} else {
 			$this->Mailer->reset();
@@ -401,7 +395,7 @@ class SetupComponent extends Component {
 		$this->Mailer->setSubject($title);
 		//FIXME
 		//$this->Mailer->setTemplate('simple_email');
-		$this->Mailer->setViewVars(compact('text'));
+		$this->Mailer->setViewVars(['text' => $text]);
 		$this->Mailer->send();
 
 		return true;

--- a/src/Healthcheck/Check/Core/CakeVersionCheck.php
+++ b/src/Healthcheck/Check/Core/CakeVersionCheck.php
@@ -65,7 +65,7 @@ class CakeVersionCheck extends Check {
 			return false;
 		}
 
-		if (str_starts_with((string) $version, 'dev-') || str_ends_with((string) $version, '-dev')) {
+		if (str_starts_with((string)$version, 'dev-') || str_ends_with((string)$version, '-dev')) {
 			$this->infoMessage[] = 'CakePHP is installed as dev version `' . $version . '`, which is not recommended for production.';
 
 			return true;

--- a/src/Healthcheck/Check/Core/CakeVersionCheck.php
+++ b/src/Healthcheck/Check/Core/CakeVersionCheck.php
@@ -65,7 +65,7 @@ class CakeVersionCheck extends Check {
 			return false;
 		}
 
-		if (str_starts_with($version, 'dev-') || str_ends_with($version, '-dev')) {
+		if (str_starts_with((string) $version, 'dev-') || str_ends_with((string) $version, '-dev')) {
 			$this->infoMessage[] = 'CakePHP is installed as dev version `' . $version . '`, which is not recommended for production.';
 
 			return true;

--- a/src/Healthcheck/Check/Core/CookieSecurityCheck.php
+++ b/src/Healthcheck/Check/Core/CookieSecurityCheck.php
@@ -47,7 +47,7 @@ class CookieSecurityCheck extends Check {
 	protected function checkHttpOnly(): void {
 		$httpOnly = ini_get('session.cookie_httponly');
 
-		if ($httpOnly === false || $httpOnly === '' || $httpOnly === '0') {
+		if (in_array($httpOnly, [false, '', '0'], true)) {
 			$this->warningMessage[] = 'session.cookie_httponly is disabled. Enable it to prevent JavaScript access to session cookies (XSS mitigation).';
 			$this->infoMessage[] = 'Set in php.ini: session.cookie_httponly = 1 or in CakePHP config: \'Session\' => [\'ini\' => [\'session.cookie_httponly\' => true]]';
 			$this->passed = false;
@@ -63,7 +63,7 @@ class CookieSecurityCheck extends Check {
 	 */
 	protected function checkSecure(): void {
 		$secure = ini_get('session.cookie_secure');
-		$isEnabled = $secure !== false && $secure !== '' && $secure !== '0';
+		$isEnabled = !in_array($secure, [false, '', '0'], true);
 
 		// In debug mode, secure cookies are optional (local dev often uses HTTP)
 		if ($this->isDebug) {
@@ -128,7 +128,7 @@ class CookieSecurityCheck extends Check {
 	protected function checkStrictMode(): void {
 		$strictMode = ini_get('session.use_strict_mode');
 
-		if ($strictMode === false || $strictMode === '' || $strictMode === '0') {
+		if (in_array($strictMode, [false, '', '0'], true)) {
 			$this->warningMessage[] = 'session.use_strict_mode is disabled. Enable it to reject uninitialized session IDs (session fixation mitigation).';
 			$this->infoMessage[] = 'Set in php.ini: session.use_strict_mode = 1 or in CakePHP config: \'Session\' => [\'ini\' => [\'session.use_strict_mode\' => true]]';
 			$this->passed = false;

--- a/src/Healthcheck/Check/Core/DebugKitDisabledCheck.php
+++ b/src/Healthcheck/Check/Core/DebugKitDisabledCheck.php
@@ -37,11 +37,7 @@ class DebugKitDisabledCheck extends Check {
 
 		if ($this->isDebug) {
 			$this->passed = true;
-			if ($isLoaded) {
-				$this->infoMessage[] = 'DebugKit is loaded (acceptable in development).';
-			} else {
-				$this->infoMessage[] = 'DebugKit is not loaded.';
-			}
+			$this->infoMessage[] = $isLoaded ? 'DebugKit is loaded (acceptable in development).' : 'DebugKit is not loaded.';
 
 			return;
 		}

--- a/src/Healthcheck/Check/Environment/AllowUrlIncludeCheck.php
+++ b/src/Healthcheck/Check/Environment/AllowUrlIncludeCheck.php
@@ -26,7 +26,7 @@ class AllowUrlIncludeCheck extends Check {
 	 */
 	public function check(): void {
 		$allowUrlInclude = ini_get('allow_url_include');
-		$isEnabled = $allowUrlInclude !== false && $allowUrlInclude !== '' && $allowUrlInclude !== '0' && strtolower($allowUrlInclude) !== 'off';
+		$isEnabled = !in_array($allowUrlInclude, [false, '', '0'], true) && strtolower($allowUrlInclude) !== 'off';
 
 		if ($isEnabled) {
 			$this->passed = false;

--- a/src/Healthcheck/Check/Environment/ExposePhpCheck.php
+++ b/src/Healthcheck/Check/Environment/ExposePhpCheck.php
@@ -39,7 +39,7 @@ class ExposePhpCheck extends Check {
 		}
 
 		$exposePhp = ini_get('expose_php');
-		$isEnabled = $exposePhp !== false && $exposePhp !== '' && $exposePhp !== '0' && strtolower($exposePhp) !== 'off';
+		$isEnabled = !in_array($exposePhp, [false, '', '0'], true) && strtolower($exposePhp) !== 'off';
 
 		if ($isEnabled) {
 			$this->passed = true;

--- a/src/Healthcheck/Check/Environment/OpcacheEnabledCheck.php
+++ b/src/Healthcheck/Check/Environment/OpcacheEnabledCheck.php
@@ -157,10 +157,8 @@ class OpcacheEnabledCheck extends Check {
 			}
 		}
 
-		if (isset($directives['opcache.enable_file_override'])) {
-			if (!$directives['opcache.enable_file_override']) {
-				$this->infoMessage[] = 'opcache.enable_file_override is disabled. Enable it for better performance with file_exists(), is_file(), etc.';
-			}
+		if (isset($directives['opcache.enable_file_override']) && !$directives['opcache.enable_file_override']) {
+			$this->infoMessage[] = 'opcache.enable_file_override is disabled. Enable it for better performance with file_exists(), is_file(), etc.';
 		}
 	}
 

--- a/src/Healthcheck/Check/Environment/PhpErrorDisplayCheck.php
+++ b/src/Healthcheck/Check/Environment/PhpErrorDisplayCheck.php
@@ -33,7 +33,7 @@ class PhpErrorDisplayCheck extends Check {
 	 */
 	public function check(): void {
 		$displayErrors = ini_get('display_errors');
-		$isEnabled = $displayErrors !== false && $displayErrors !== '' && $displayErrors !== '0' && strtolower($displayErrors) !== 'off';
+		$isEnabled = !in_array($displayErrors, [false, '', '0'], true) && strtolower($displayErrors) !== 'off';
 
 		if ($this->isDebug) {
 			$this->passed = true;

--- a/src/Healthcheck/Check/Environment/PhpExtensionsCheck.php
+++ b/src/Healthcheck/Check/Environment/PhpExtensionsCheck.php
@@ -118,8 +118,8 @@ class PhpExtensionsCheck extends Check {
 
 		$extensions = [];
 		foreach ($composer['require'] as $key => $value) {
-			if (str_starts_with($key, 'ext-')) {
-				$extension = substr($key, 4);
+			if (str_starts_with((string) $key, 'ext-')) {
+				$extension = substr((string) $key, 4);
 				if ($this->satisfiesVersion($value)) {
 					$extensions[] = $extension;
 				}

--- a/src/Healthcheck/Check/Environment/PhpExtensionsCheck.php
+++ b/src/Healthcheck/Check/Environment/PhpExtensionsCheck.php
@@ -118,8 +118,8 @@ class PhpExtensionsCheck extends Check {
 
 		$extensions = [];
 		foreach ($composer['require'] as $key => $value) {
-			if (str_starts_with((string) $key, 'ext-')) {
-				$extension = substr((string) $key, 4);
+			if (str_starts_with((string)$key, 'ext-')) {
+				$extension = substr((string)$key, 4);
 				if ($this->satisfiesVersion($value)) {
 					$extensions[] = $extension;
 				}

--- a/src/Healthcheck/Check/Environment/PhpVersionCheck.php
+++ b/src/Healthcheck/Check/Environment/PhpVersionCheck.php
@@ -242,10 +242,8 @@ class PhpVersionCheck extends Check {
 		$basePatch = (int)($baseParts[2] ?? 0);
 
 		// Check if version is lower than minimum requirement
-		if ($operator === '>=' || $operator === '>') {
-			if (version_compare($version, $baseVersion, '<')) {
-				return 'lower';
-			}
+		if (($operator === '>=' || $operator === '>') && version_compare($version, $baseVersion, '<')) {
+			return 'lower';
 		}
 
 		// For caret (^) operator: ^8.1 means >=8.1.0 <9.0.0

--- a/src/Healthcheck/Healthcheck.php
+++ b/src/Healthcheck/Healthcheck.php
@@ -43,11 +43,9 @@ class Healthcheck {
 			if ($check->passed() && $check->warningMessage()) {
 				$reflection = new ReflectionClass($check);
 				$passedProperty = $reflection->getProperty('passed');
-				$passedProperty->setAccessible(true);
 				$passedProperty->setValue($check, false);
 
 				$levelProperty = $reflection->getProperty('level');
-				$levelProperty->setAccessible(true);
 				$levelProperty->setValue($check, CheckInterface::LEVEL_WARNING);
 			}
 

--- a/src/Maintenance/Maintenance.php
+++ b/src/Maintenance/Maintenance.php
@@ -117,7 +117,7 @@ class Maintenance {
 	public function addToWhitelist(array $newIps = []) {
 		foreach ($newIps as $ip) {
 				$this->_addToWhitelist($ip);
-			}
+		}
 	}
 
 	/**
@@ -184,7 +184,8 @@ class Maintenance {
 		if (!str_contains($content, $ip)) {
 			$content .= PHP_EOL . $ip;
 		}
-        return (bool) file_put_contents($this->whitelistFile, trim($content));
+
+		return (bool)file_put_contents($this->whitelistFile, trim($content));
 	}
 
 }

--- a/src/Maintenance/Maintenance.php
+++ b/src/Maintenance/Maintenance.php
@@ -115,11 +115,9 @@ class Maintenance {
 	 * @return void
 	 */
 	public function addToWhitelist(array $newIps = []) {
-		if ($newIps) {
-			foreach ($newIps as $ip) {
+		foreach ($newIps as $ip) {
 				$this->_addToWhitelist($ip);
 			}
-		}
 	}
 
 	/**
@@ -186,11 +184,7 @@ class Maintenance {
 		if (!str_contains($content, $ip)) {
 			$content .= PHP_EOL . $ip;
 		}
-		if (!file_put_contents($this->whitelistFile, trim($content))) {
-			return false;
-		}
-
-		return true;
+        return (bool) file_put_contents($this->whitelistFile, trim($content));
 	}
 
 }

--- a/src/Maintenance/Maintenance.php
+++ b/src/Maintenance/Maintenance.php
@@ -116,7 +116,7 @@ class Maintenance {
 	 */
 	public function addToWhitelist(array $newIps = []) {
 		foreach ($newIps as $ip) {
-				$this->_addToWhitelist($ip);
+			$this->_addToWhitelist($ip);
 		}
 	}
 

--- a/src/Middleware/MaintenanceMiddleware.php
+++ b/src/Middleware/MaintenanceMiddleware.php
@@ -58,9 +58,7 @@ class MaintenanceMiddleware implements MiddlewareInterface {
 			return $response;
 		}
 
-		$response = $this->build($response);
-
-		return $response;
+		return $this->build($response);
 	}
 
 	/**

--- a/src/Queue/Task/HealthcheckTask.php
+++ b/src/Queue/Task/HealthcheckTask.php
@@ -33,17 +33,15 @@ class HealthcheckTask extends Task implements AddInterface, AddFromBackendInterf
 			foreach ($checks as $check) {
 				$message .= ' - ' . $check->name() . ': ' . ($check->passed() ? 'OK' : 'FAIL') . PHP_EOL;
 				if (!$check->passed()) {
-					if ($check->failureMessage()) {
+                    if ($check->failureMessage()) {
 						$message .= '   Error: ' . implode(', ', $check->failureMessage()) . PHP_EOL;
 					}
-					if ($check->warningMessage()) {
+                    if ($check->warningMessage()) {
 						$message .= '   Warning: ' . implode(', ', $check->warningMessage()) . PHP_EOL;
 					}
-				} else {
-					if ($check->successMessage()) {
-						$message .= '   Passed: ' . implode(', ', $check->successMessage()) . PHP_EOL;
-					}
-				}
+                } elseif ($check->successMessage()) {
+                    $message .= '   Passed: ' . implode(', ', $check->successMessage()) . PHP_EOL;
+                }
 
 				if ($check->infoMessage()) {
 					$message .= '   Info: ' . implode(', ', $check->infoMessage()) . PHP_EOL;

--- a/src/Queue/Task/HealthcheckTask.php
+++ b/src/Queue/Task/HealthcheckTask.php
@@ -33,15 +33,15 @@ class HealthcheckTask extends Task implements AddInterface, AddFromBackendInterf
 			foreach ($checks as $check) {
 				$message .= ' - ' . $check->name() . ': ' . ($check->passed() ? 'OK' : 'FAIL') . PHP_EOL;
 				if (!$check->passed()) {
-                    if ($check->failureMessage()) {
+					if ($check->failureMessage()) {
 						$message .= '   Error: ' . implode(', ', $check->failureMessage()) . PHP_EOL;
 					}
-                    if ($check->warningMessage()) {
+					if ($check->warningMessage()) {
 						$message .= '   Warning: ' . implode(', ', $check->warningMessage()) . PHP_EOL;
 					}
-                } elseif ($check->successMessage()) {
-                    $message .= '   Passed: ' . implode(', ', $check->successMessage()) . PHP_EOL;
-                }
+				} elseif ($check->successMessage()) {
+					$message .= '   Passed: ' . implode(', ', $check->successMessage()) . PHP_EOL;
+				}
 
 				if ($check->infoMessage()) {
 					$message .= '   Info: ' . implode(', ', $check->infoMessage()) . PHP_EOL;

--- a/src/TestSuite/DriverSkipTrait.php
+++ b/src/TestSuite/DriverSkipTrait.php
@@ -16,7 +16,7 @@ trait DriverSkipTrait {
 	 */
 	protected function skipIfNotDriver(string $type, string $message = '') {
 		$config = ConnectionManager::getConfig('test');
-		$this->skipIf(strpos($config['driver'], $type) === false, $message);
+		$this->skipIf(!str_contains((string) $config['driver'], $type), $message);
 	}
 
 	/**
@@ -26,7 +26,7 @@ trait DriverSkipTrait {
 	 */
 	protected function skipIfDriver(string $type, string $message = '') {
 		$config = ConnectionManager::getConfig('test');
-		$this->skipIf(strpos($config['driver'], $type) !== false, $message);
+		$this->skipIf(str_contains((string) $config['driver'], $type), $message);
 	}
 
 }

--- a/src/TestSuite/DriverSkipTrait.php
+++ b/src/TestSuite/DriverSkipTrait.php
@@ -16,7 +16,7 @@ trait DriverSkipTrait {
 	 */
 	protected function skipIfNotDriver(string $type, string $message = '') {
 		$config = ConnectionManager::getConfig('test');
-		$this->skipIf(!str_contains((string) $config['driver'], $type), $message);
+		$this->skipIf(!str_contains((string)$config['driver'], $type), $message);
 	}
 
 	/**
@@ -26,7 +26,7 @@ trait DriverSkipTrait {
 	 */
 	protected function skipIfDriver(string $type, string $message = '') {
 		$config = ConnectionManager::getConfig('test');
-		$this->skipIf(str_contains((string) $config['driver'], $type), $message);
+		$this->skipIf(str_contains((string)$config['driver'], $type), $message);
 	}
 
 }

--- a/src/Utility/ClassFinder.php
+++ b/src/Utility/ClassFinder.php
@@ -49,7 +49,7 @@ class ClassFinder {
 			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 			foreach ($folderContent[1] as $file) {
-				$name = pathinfo($file, PATHINFO_FILENAME);
+				$name = pathinfo((string) $file, PATHINFO_FILENAME);
 				$names[] = $name;
 			}
 
@@ -57,7 +57,7 @@ class ClassFinder {
 				$folderContent = (new Folder($folder . $subFolder))->read(Folder::SORT_NAME, true);
 
 				foreach ($folderContent[1] as $file) {
-					$name = pathinfo($file, PATHINFO_FILENAME);
+					$name = pathinfo((string) $file, PATHINFO_FILENAME);
 					$names[] = $subFolder . '/' . $name;
 				}
 			}

--- a/src/Utility/ClassFinder.php
+++ b/src/Utility/ClassFinder.php
@@ -49,7 +49,7 @@ class ClassFinder {
 			$folderContent = (new Folder($folder))->read(Folder::SORT_NAME, true);
 
 			foreach ($folderContent[1] as $file) {
-				$name = pathinfo((string) $file, PATHINFO_FILENAME);
+				$name = pathinfo((string)$file, PATHINFO_FILENAME);
 				$names[] = $name;
 			}
 
@@ -57,7 +57,7 @@ class ClassFinder {
 				$folderContent = (new Folder($folder . $subFolder))->read(Folder::SORT_NAME, true);
 
 				foreach ($folderContent[1] as $file) {
-					$name = pathinfo((string) $file, PATHINFO_FILENAME);
+					$name = pathinfo((string)$file, PATHINFO_FILENAME);
 					$names[] = $subFolder . '/' . $name;
 				}
 			}

--- a/src/Utility/Config.php
+++ b/src/Utility/Config.php
@@ -101,10 +101,6 @@ class Config {
 			return $value;
 		}
 
-		if (in_array(strtoupper($value), ['0', '1', 'TRUE', 'FALSE'], true)) {
-			return $value;
-		}
-
 		return $value;
 	}
 

--- a/src/Utility/Debug.php
+++ b/src/Utility/Debug.php
@@ -183,7 +183,7 @@ class Debug {
 			// If you find or miss one, please tell me.
 			switch ($key) {
 				case 'model name':
-				case 'cpu': // for ix86
+				case 'cpu':
 					$results[$processors]['model'] = $value;
 
 					break;

--- a/src/Utility/Debug.php
+++ b/src/Utility/Debug.php
@@ -130,29 +130,24 @@ class Debug {
 	public function getKernelVersion() {
 		$fh = fopen('/proc/version', 'r');
 		if ($fh) {
-			$buffer = (string)fgets($fh, 4096);
-			fclose($fh);
-
-			// search and grep the kernel-version
-			if (preg_match('/version (.*?) /', $buffer, $matches)) {
-				$result = $matches[1];
-				if (preg_match('/SMP/', $buffer)) {
+            $buffer = (string)fgets($fh, 4096);
+            fclose($fh);
+            // search and grep the kernel-version
+            if (preg_match('/version (.*?) /', $buffer, $matches)) {
+                $result = $matches[1];
+                if (preg_match('/SMP/', $buffer)) {
 					$result .= ' (SMP)';
 				}
-			} else {
-				if ($this->useFillString) {
-					$result = $this->fillString;
-				} else {
+            } elseif ($this->useFillString) {
+                $result = $this->fillString;
+            } else {
 					$result = '';
 				}
-			}
-		} else {
-			if ($this->useFillString) {
-				$result = $this->fillString;
-			} else {
+        } elseif ($this->useFillString) {
+            $result = $this->fillString;
+        } else {
 				$result = '';
 			}
-		}
 
 		return $result;
 	}
@@ -187,20 +182,13 @@ class Debug {
 			// Maybe you need some other tags if you run this on another architecture.
 			// If you find or miss one, please tell me.
 			switch ($key) {
-				case 'model name': // for ix86
-					$results[$processors]['model'] = $value;
+				case 'model name':
+                case 'cpu': // for ix86
+                    $results[$processors]['model'] = $value;
 
 					break;
 				case 'cpu MHz':
-					$results[$processors]['mhz'] = sprintf('%.2f', $value);
-
-					break;
-				case 'clock': // for PPC
-					$results[$processors]['mhz'] = sprintf('%.2f', $value);
-
-					break;
-				case 'cpu': // for PPC
-					$results[$processors]['model'] = $value;
+				case 'clock': $results[$processors]['mhz'] = sprintf('%.2f', $value);
 
 					break;
 				case 'cpu cores': // for PPC
@@ -252,7 +240,7 @@ class Debug {
 		];
 
 		while ($buffer = fgets($fh, 4096)) {
-			if (strpos($buffer, ':') === false) {
+			if (!str_contains($buffer, ':')) {
 				continue;
 			}
 			[$key, $value] = explode(':', trim($buffer), 2);
@@ -326,11 +314,7 @@ class Debug {
 		if (ini_set('memory_limit', $int . 'M') === false) {
 			return false;
 		}
-		if ($this->memoryLimit() !== $int . 'M') {
-			return false;
-		}
-
-		return true;
+        return $this->memoryLimit() === $int . 'M';
 	}
 
 	/**
@@ -364,7 +348,7 @@ class Debug {
 		$res = exec($command);
 
 		//$s = system($command);
-		return $res ? true : false;
+		return (bool) $res;
 	}
 
 	/**
@@ -441,11 +425,7 @@ class Debug {
 	 */
 	public function extensionLoaded($extensionName) {
 		$e = $this->loadedExtensions();
-		if (in_array(strtolower($extensionName), $e)) {
-			return true;
-		}
-
-		return false;
+        return in_array(strtolower($extensionName), $e);
 	}
 
 	/**
@@ -483,40 +463,29 @@ class Debug {
 	 */
 	public function openBasedir() {
 		$var = (string)ini_get('open_basedir');
-		if (str_contains($var, ':')) {
-			$paths = explode(':', $var);
-		} else {
-			$paths = [];
-		}
 
-		return $paths;
+		return str_contains($var, ':') ? explode(':', $var) : [];
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function displayErrors() {
-		$res = (bool)ini_get('display_errors');
-
-		return $res;
+		return (bool)ini_get('display_errors');
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function allowUrlFopen() {
-		$res = (bool)ini_get('allow_url_fopen');
-
-		return $res;
+		return (bool)ini_get('allow_url_fopen');
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function fileUpload() {
-		$res = (bool)ini_get('file_uploads');
-
-		return $res;
+		return (bool)ini_get('file_uploads');
 	}
 
 	/**
@@ -551,9 +520,7 @@ class Debug {
 	 * @return bool
 	 */
 	public function registerLongArrays() {
-		$res = (bool)ini_get('register_long_arrays');
-
-		return $res;
+		return (bool)ini_get('register_long_arrays');
 	}
 
 	/**
@@ -562,9 +529,7 @@ class Debug {
 	 * @return bool
 	 */
 	public function registerArgcArgv() {
-		$res = (bool)ini_get('register_argc_argv');
-
-		return $res;
+		return (bool)ini_get('register_argc_argv');
 	}
 
 	/**
@@ -573,9 +538,7 @@ class Debug {
 	 * @return int
 	 */
 	public function maxExecTime() {
-		$res = (int)ini_get('max_execution_time');
-
-		return $res;
+		return (int)ini_get('max_execution_time');
 	}
 
 	/**

--- a/src/Utility/Debug.php
+++ b/src/Utility/Debug.php
@@ -130,24 +130,24 @@ class Debug {
 	public function getKernelVersion() {
 		$fh = fopen('/proc/version', 'r');
 		if ($fh) {
-            $buffer = (string)fgets($fh, 4096);
-            fclose($fh);
-            // search and grep the kernel-version
-            if (preg_match('/version (.*?) /', $buffer, $matches)) {
-                $result = $matches[1];
-                if (preg_match('/SMP/', $buffer)) {
+			$buffer = (string)fgets($fh, 4096);
+			fclose($fh);
+			// search and grep the kernel-version
+			if (preg_match('/version (.*?) /', $buffer, $matches)) {
+				$result = $matches[1];
+				if (preg_match('/SMP/', $buffer)) {
 					$result .= ' (SMP)';
 				}
-            } elseif ($this->useFillString) {
-                $result = $this->fillString;
-            } else {
+			} elseif ($this->useFillString) {
+				$result = $this->fillString;
+			} else {
 					$result = '';
-				}
-        } elseif ($this->useFillString) {
-            $result = $this->fillString;
-        } else {
-				$result = '';
 			}
+		} elseif ($this->useFillString) {
+			$result = $this->fillString;
+		} else {
+				$result = '';
+		}
 
 		return $result;
 	}
@@ -183,12 +183,13 @@ class Debug {
 			// If you find or miss one, please tell me.
 			switch ($key) {
 				case 'model name':
-                case 'cpu': // for ix86
-                    $results[$processors]['model'] = $value;
+				case 'cpu': // for ix86
+					$results[$processors]['model'] = $value;
 
 					break;
 				case 'cpu MHz':
-				case 'clock': $results[$processors]['mhz'] = sprintf('%.2f', $value);
+				case 'clock':
+					$results[$processors]['mhz'] = sprintf('%.2f', $value);
 
 					break;
 				case 'cpu cores': // for PPC
@@ -314,7 +315,8 @@ class Debug {
 		if (ini_set('memory_limit', $int . 'M') === false) {
 			return false;
 		}
-        return $this->memoryLimit() === $int . 'M';
+
+		return $this->memoryLimit() === $int . 'M';
 	}
 
 	/**
@@ -348,7 +350,7 @@ class Debug {
 		$res = exec($command);
 
 		//$s = system($command);
-		return (bool) $res;
+		return (bool)$res;
 	}
 
 	/**
@@ -425,7 +427,8 @@ class Debug {
 	 */
 	public function extensionLoaded($extensionName) {
 		$e = $this->loadedExtensions();
-        return in_array(strtolower($extensionName), $e);
+
+		return in_array(strtolower($extensionName), $e);
 	}
 
 	/**

--- a/src/Utility/Setup.php
+++ b/src/Utility/Setup.php
@@ -23,7 +23,7 @@ class Setup {
 			}
 		}
 
-		$pass = !empty($urlArray['pass']) ? $urlArray['pass'] : [];
+		$pass = empty($urlArray['pass']) ? [] : $urlArray['pass'];
 
 		$returnArray = [];
 		if (isset($urlArray['controller'])) {

--- a/src/Utility/System.php
+++ b/src/Utility/System.php
@@ -42,7 +42,7 @@ class System {
 			$value &= ~E_ALL;
 		}
 		foreach ($levelNames as $level => $name) {
-			if (($value & $level) == $level) {
+			if (($value & $level) === $level) {
 				$levels[] = $name;
 			}
 		}
@@ -53,7 +53,7 @@ class System {
 
 		$disabled = [];
 		foreach ($levelNames as $level => $name) {
-			if (($originalValue & $level) != $level) {
+			if (($originalValue & $level) !== $level) {
 				$disabled[] = $name;
 			}
 		}
@@ -131,7 +131,7 @@ class System {
 			'used' => 0,
 			'available' => 0,
 		];
-		$command = sprintf('df');
+		$command = 'df';
 		exec($command, $output, $status);
 		if ($status !== 0) { # zero => success
 			return $space;
@@ -204,11 +204,11 @@ class System {
 			return;
 		}
 
-		$sizeAndPath = explode("\t", $data[$rootKey]);
+		$sizeAndPath = explode("\t", (string) $data[$rootKey]);
 		$urlToRoot = trim($sizeAndPath[1]);
 
 		foreach ($data as $key => $value) {
-			$sizeAndPath = explode("\t", $value);
+			$sizeAndPath = explode("\t", (string) $value);
 			$size = $sizeAndPath[0];
 			$url = str_replace($urlToRoot, '', $sizeAndPath[1]);
 			if (empty($url)) {
@@ -255,7 +255,7 @@ class System {
 	 */
 	public function _generateTree(&$data, $root) {
 		$res = [];
-		$sizeAndPath = explode("\t", $data[$root]);
+		$sizeAndPath = explode("\t", (string) $data[$root]);
 		$urlToRoot = $sizeAndPath[1];
 		$sizeOfRoot = $sizeAndPath[0];
 		// root
@@ -266,7 +266,7 @@ class System {
 		];
 
 		for ($i = $root; $i >= 0; $i--) {
-			$sizeAndPath = explode("\t", $data[$i]);
+			$sizeAndPath = explode("\t", (string) $data[$i]);
 
 			$name = str_replace($urlToRoot, "\t", $sizeAndPath[1]);
 			// split by DS
@@ -288,7 +288,7 @@ class System {
 		$length = 0;
 		$index = null;
 		foreach ($data as $key => $value) {
-			$newLength = mb_strlen($value);
+			$newLength = mb_strlen((string) $value);
 			if (!$length || $newLength < $length) {
 				$length = $newLength;
 				$index = (int)$key;

--- a/src/Utility/System.php
+++ b/src/Utility/System.php
@@ -204,11 +204,11 @@ class System {
 			return;
 		}
 
-		$sizeAndPath = explode("\t", (string) $data[$rootKey]);
+		$sizeAndPath = explode("\t", (string)$data[$rootKey]);
 		$urlToRoot = trim($sizeAndPath[1]);
 
 		foreach ($data as $key => $value) {
-			$sizeAndPath = explode("\t", (string) $value);
+			$sizeAndPath = explode("\t", (string)$value);
 			$size = $sizeAndPath[0];
 			$url = str_replace($urlToRoot, '', $sizeAndPath[1]);
 			if (empty($url)) {
@@ -255,7 +255,7 @@ class System {
 	 */
 	public function _generateTree(&$data, $root) {
 		$res = [];
-		$sizeAndPath = explode("\t", (string) $data[$root]);
+		$sizeAndPath = explode("\t", (string)$data[$root]);
 		$urlToRoot = $sizeAndPath[1];
 		$sizeOfRoot = $sizeAndPath[0];
 		// root
@@ -266,7 +266,7 @@ class System {
 		];
 
 		for ($i = $root; $i >= 0; $i--) {
-			$sizeAndPath = explode("\t", (string) $data[$i]);
+			$sizeAndPath = explode("\t", (string)$data[$i]);
 
 			$name = str_replace($urlToRoot, "\t", $sizeAndPath[1]);
 			// split by DS
@@ -288,7 +288,7 @@ class System {
 		$length = 0;
 		$index = null;
 		foreach ($data as $key => $value) {
-			$newLength = mb_strlen((string) $value);
+			$newLength = mb_strlen((string)$value);
 			if (!$length || $newLength < $length) {
 				$length = $newLength;
 				$index = (int)$key;

--- a/src/View/Helper/SetupBakeHelper.php
+++ b/src/View/Helper/SetupBakeHelper.php
@@ -97,11 +97,7 @@ class SetupBakeHelper extends BakeHelper {
 		}
 
 		$fieldData = (array)$schema->getColumn($field);
-		if (in_array($field, $paginationOrderReversedFields, true) || in_array($fieldData['type'], $paginationOrderReversedFieldTypes, true)) {
-			return true;
-		}
-
-		return false;
+        return in_array($field, $paginationOrderReversedFields, true) || in_array($fieldData['type'], $paginationOrderReversedFieldTypes, true);
 	}
 
 	/**

--- a/src/View/Helper/SetupBakeHelper.php
+++ b/src/View/Helper/SetupBakeHelper.php
@@ -97,7 +97,8 @@ class SetupBakeHelper extends BakeHelper {
 		}
 
 		$fieldData = (array)$schema->getColumn($field);
-        return in_array($field, $paginationOrderReversedFields, true) || in_array($fieldData['type'], $paginationOrderReversedFieldTypes, true);
+
+		return in_array($field, $paginationOrderReversedFields, true) || in_array($fieldData['type'], $paginationOrderReversedFieldTypes, true);
 	}
 
 	/**

--- a/tests/TestCase/Controller/Component/SetupComponentTest.php
+++ b/tests/TestCase/Controller/Component/SetupComponentTest.php
@@ -61,7 +61,7 @@ class SetupComponentTest extends TestCase {
 			->withQueryParams(['maintenance' => 1]);
 		$this->Controller->setRequest($request);
 
-		$event = new Event('Controller.startup', $this->Controller, compact('request'));
+		$event = new Event('Controller.startup', $this->Controller, ['request' => $request]);
 
 		$this->Setup->beforeFilter($event);
 
@@ -101,7 +101,7 @@ class SetupComponentTest extends TestCase {
 		$this->Controller->loadComponent('Flash');
 		$this->Setup = new SetupComponent(new ComponentRegistry($this->Controller));
 
-		$event = new Event('Controller.startup', $this->Controller, compact('request'));
+		$event = new Event('Controller.startup', $this->Controller, ['request' => $request]);
 
 		$this->Setup->beforeFilter($event);
 

--- a/tests/TestCase/Healthcheck/Check/Database/ConnectCheckTest.php
+++ b/tests/TestCase/Healthcheck/Check/Database/ConnectCheckTest.php
@@ -60,7 +60,7 @@ class ConnectCheckTest extends TestCase {
 	 * @return void
 	 */
 	public function testCheckWithNullConnection() {
-		$check = new ConnectCheck(null); // Should default to 'default'
+		$check = new ConnectCheck(); // Should default to 'default'
 
 		$check->check();
 		$this->assertTrue($check->passed());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,7 +18,7 @@ if (!defined('DS')) {
 	define('DS', DIRECTORY_SEPARATOR);
 }
 if (!defined('WINDOWS')) {
-	if (DS == '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+	if (DS === '\\' || str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -21,7 +21,7 @@ foreach ($iterator as $file) {
 		$tableObject = (new ReflectionClass($class))->getProperty('table');
 		$tableName = $tableObject->getDefaultValue();
 
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.