### PR TITLE
Queue healthcheck task outputs summary and log hint

### DIFF
--- a/src/Queue/Task/HealthcheckTask.php
+++ b/src/Queue/Task/HealthcheckTask.php
@@ -22,11 +22,15 @@ class HealthcheckTask extends Task implements AddInterface, AddFromBackendInterf
 		$passed = $healthcheck->run($data['domain'] ?? null);
 
 		$result = $healthcheck->result();
+		$totalCount = $result->unfold()->count();
+		$domainCount = count($result);
+		$errors = $healthcheck->errors();
+		$warnings = $healthcheck->warnings();
 		$message = 'Healthcheck queue run ' . ($passed ? 'OK' : 'FAIL');
 		$message .= PHP_EOL . PHP_EOL;
 		/**
 		 * @var string $domain
-		 * @var \Setup\Healthcheck\Check\CheckInterface[] $checks
+		 * @var iterable<\Setup\Healthcheck\Check\CheckInterface> $checks
 		 */
 		foreach ($result as $domain => $checks) {
 			$message .= '### ' . $domain . PHP_EOL;
@@ -51,6 +55,25 @@ class HealthcheckTask extends Task implements AddInterface, AddFromBackendInterf
 			}
 		}
 
+		$this->io->out('Healthcheck: ' . ($passed ? 'OK' : 'FAIL'));
+		$this->io->out(sprintf(
+			'Summary: %d check(s) in %d domain(s); errors=%d; warnings=%d.',
+			$totalCount,
+			$domainCount,
+			$errors,
+			$warnings,
+		));
+
+		$relevantChecks = $this->relevantChecks($result);
+		if ($relevantChecks !== []) {
+			$this->io->out('Relevant checks:');
+			foreach ($relevantChecks as $line) {
+				$this->io->out(' - ' . $line);
+			}
+		}
+
+		$this->io->out('See the configured log target for full healthcheck details.');
+
 		Log::write($passed ? 'info' : 'warning', $message);
 	}
 
@@ -64,6 +87,35 @@ class HealthcheckTask extends Task implements AddInterface, AddFromBackendInterf
 		];
 		$this->QueuedJobs->createJob('Setup.Healthcheck', $data);
 		$this->io->success('OK, job created, now run the worker');
+	}
+
+	/**
+	 * @param iterable<string, iterable<\Setup\Healthcheck\Check\CheckInterface>> $result
+	 *
+	 * @return list<string>
+	 */
+	protected function relevantChecks(iterable $result): array {
+		$lines = [];
+
+		foreach ($result as $domain => $checks) {
+			foreach ($checks as $check) {
+				if ($check->passed() && !$check->warningMessage()) {
+					continue;
+				}
+
+				$status = $check->passed() ? 'WARN' : 'FAIL';
+				$detail = '';
+				if (!$check->passed() && $check->failureMessage()) {
+					$detail = ' - ' . implode(', ', $check->failureMessage());
+				} elseif ($check->warningMessage()) {
+					$detail = ' - ' . implode(', ', $check->warningMessage());
+				}
+
+				$lines[] = $domain . '/' . $check->name() . ': ' . $status . $detail;
+			}
+		}
+
+		return $lines;
 	}
 
 }

--- a/src/Queue/Task/HealthcheckTask.php
+++ b/src/Queue/Task/HealthcheckTask.php
@@ -2,6 +2,7 @@
 
 namespace Setup\Queue\Task;
 
+use Cake\Collection\CollectionInterface;
 use Cake\Log\Log;
 use Queue\Queue\AddFromBackendInterface;
 use Queue\Queue\AddInterface;
@@ -90,14 +91,18 @@ class HealthcheckTask extends Task implements AddInterface, AddFromBackendInterf
 	}
 
 	/**
-	 * @param iterable<string, iterable<\Setup\Healthcheck\Check\CheckInterface>> $result
+	 * @param \Cake\Collection\CollectionInterface<\Setup\Healthcheck\Check\CheckInterface> $result
 	 *
 	 * @return list<string>
 	 */
-	protected function relevantChecks(iterable $result): array {
+	protected function relevantChecks(CollectionInterface $result): array {
 		$lines = [];
 
 		foreach ($result as $domain => $checks) {
+			if (!is_iterable($checks)) {
+				continue;
+			}
+
 			foreach ($checks as $check) {
 				if ($check->passed() && !$check->warningMessage()) {
 					continue;

--- a/tests/TestCase/Queue/Task/HealthcheckTaskTest.php
+++ b/tests/TestCase/Queue/Task/HealthcheckTaskTest.php
@@ -2,9 +2,13 @@
 
 namespace Setup\Test\TestCase\Queue\Task;
 
+use Cake\Console\ConsoleIo;
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
-use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use Queue\Console\Io;
+use Setup\Healthcheck\Check\Environment\PhpVersionCheck;
 use Setup\Queue\Task\HealthcheckTask;
+use Shim\TestSuite\ConsoleOutput;
 
 class HealthcheckTaskTest extends TestCase {
 
@@ -16,11 +20,22 @@ class HealthcheckTaskTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	#[DoesNotPerformAssertions]
 	public function testRun(): void {
-		$task = new HealthcheckTask();
+		Configure::write('Setup.Healthcheck.checks', [
+			PhpVersionCheck::class,
+		]);
+
+		$out = new ConsoleOutput();
+		$err = new ConsoleOutput();
+		$io = new Io(new ConsoleIo($out, $err));
+		$task = new HealthcheckTask($io);
 
 		$task->run([], 0);
+
+		$output = $out->output();
+		$this->assertStringContainsString('Healthcheck: OK', $output);
+		$this->assertStringContainsString('Summary: 1 check(s) in 1 domain(s); errors=0; warnings=0.', $output);
+		$this->assertStringContainsString('See the configured log target for full healthcheck details.', $output);
 	}
 
 }


### PR DESCRIPTION
## Summary
- write a short queue-visible summary for `Setup.Healthcheck` jobs
- keep detailed healthcheck output in the configured log target and add a queue hint to check it
- add a focused queue-task test covering the new output

## Verification
- `vendor/bin/phpunit tests/TestCase/Queue/Task/HealthcheckTaskTest.php`
- `vendor/bin/phpcs src/Queue/Task/HealthcheckTask.php tests/TestCase/Queue/Task/HealthcheckTaskTest.php`