### PR TITLE
Resolve root-relative security.txt URI fields to absolute URLs

### DIFF
--- a/src/Middleware/SecurityTxtMiddleware.php
+++ b/src/Middleware/SecurityTxtMiddleware.php
@@ -106,7 +106,7 @@ class SecurityTxtMiddleware implements MiddlewareInterface {
 		}
 
 		/** @var array<string, mixed> $fields */
-		$fields = (array)$this->getConfig('fields');
+		$fields = $this->absolutize((array)$this->getConfig('fields'), $request);
 		$contacts = SecurityTxt::normalize($fields['Contact'] ?? null);
 
 		$response = $this->build($fields, $contacts);
@@ -134,6 +134,59 @@ class SecurityTxtMiddleware implements MiddlewareInterface {
 		}
 
 		return $path !== '' ? $path : '/';
+	}
+
+	/**
+	 * Resolve any root-relative URI field values (e.g. `/security`) to absolute
+	 * URLs using the current request's scheme and host, so the served file stays
+	 * RFC 9116 compliant (absolute URIs) while the configured values can stay
+	 * host-agnostic and travel across deploys unchanged.
+	 *
+	 * Values that are already absolute (`https:`, `mailto:`, `tel:`, ...) or
+	 * protocol-relative (`//host/...`) are left untouched. `Expires` and
+	 * `Preferred-Languages` are never URIs, so they are skipped.
+	 *
+	 * @param array<string, mixed> $fields
+	 * @param \Psr\Http\Message\ServerRequestInterface $request
+	 * @return array<string, mixed>
+	 */
+	protected function absolutize(array $fields, ServerRequestInterface $request): array {
+		$uri = $request->getUri();
+		$authority = $uri->getAuthority();
+		if ($authority === '') {
+			return $fields;
+		}
+
+		$base = $uri->getScheme() . '://' . $authority;
+		foreach ($fields as $name => $value) {
+			if ($name === 'Expires' || $name === 'Preferred-Languages') {
+				continue;
+			}
+
+			$fields[$name] = $this->absolutizeValue($value, $base);
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Prefix a single root-relative URI value (or each value in a list) with the
+	 * absolute base; pass through anything that is not root-relative.
+	 *
+	 * @param mixed $value
+	 * @param string $base
+	 * @return mixed
+	 */
+	protected function absolutizeValue(mixed $value, string $base): mixed {
+		if (is_array($value)) {
+			return array_map(fn ($item): mixed => $this->absolutizeValue($item, $base), $value);
+		}
+
+		if (is_string($value) && str_starts_with($value, '/') && !str_starts_with($value, '//')) {
+			return $base . $value;
+		}
+
+		return $value;
 	}
 
 	/**

--- a/tests/TestCase/Middleware/SecurityTxtMiddlewareTest.php
+++ b/tests/TestCase/Middleware/SecurityTxtMiddlewareTest.php
@@ -272,17 +272,104 @@ class SecurityTxtMiddlewareTest extends TestCase {
 	}
 
 	/**
+	 * Root-relative URI values are resolved to absolute URLs using the request host.
+	 *
+	 * @return void
+	 */
+	public function testRelativeUriResolvedToAbsolute(): void {
+		$middleware = new SecurityTxtMiddleware(new SecurityTxt(
+			contact: '/security',
+			canonical: '/.well-known/security.txt',
+			preferredLanguages: 'en',
+		));
+
+		$body = (string)$middleware->process(
+			$this->request('/.well-known/security.txt', host: 'example.org', https: true),
+			$this->handler(),
+		)->getBody();
+
+		$this->assertStringContainsString('Contact: https://example.org/security', $body);
+		$this->assertStringContainsString('Canonical: https://example.org/.well-known/security.txt', $body);
+		// Non-URI fields are left untouched.
+		$this->assertStringContainsString('Preferred-Languages: en', $body);
+	}
+
+	/**
+	 * The resolved scheme follows the request (http on a plain-HTTP host).
+	 *
+	 * @return void
+	 */
+	public function testRelativeUriUsesRequestScheme(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => '/security'],
+		]);
+
+		$body = (string)$middleware->process(
+			$this->request('/.well-known/security.txt', host: 'example.org'),
+			$this->handler(),
+		)->getBody();
+
+		$this->assertStringContainsString('Contact: http://example.org/security', $body);
+	}
+
+	/**
+	 * Already-absolute values (https/mailto/tel) pass through unchanged.
+	 *
+	 * @return void
+	 */
+	public function testAbsoluteUriLeftUnchanged(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => ['mailto:security@example.com', 'https://example.com/report']],
+		]);
+
+		$body = (string)$middleware->process(
+			$this->request('/.well-known/security.txt', host: 'other.example'),
+			$this->handler(),
+		)->getBody();
+
+		$this->assertStringContainsString('Contact: mailto:security@example.com', $body);
+		$this->assertStringContainsString('Contact: https://example.com/report', $body);
+		$this->assertStringNotContainsString('other.example', $body);
+	}
+
+	/**
+	 * With no explicit host the CakePHP request still carries a default authority
+	 * (`localhost`), which is used to resolve the relative value.
+	 *
+	 * @return void
+	 */
+	public function testRelativeUriUsesDefaultHost(): void {
+		$middleware = new SecurityTxtMiddleware([
+			'fields' => ['Contact' => '/security'],
+		]);
+
+		$body = (string)$middleware->process($this->request('/.well-known/security.txt'), $this->handler())->getBody();
+
+		$this->assertStringContainsString('Contact: http://localhost/security', $body);
+	}
+
+	/**
 	 * Build a request for the given path and method.
 	 *
 	 * @param string $path
 	 * @param string $method
+	 * @param string|null $host Optional `HTTP_HOST` so the request has an authority.
+	 * @param bool $https Whether the request is served over HTTPS.
 	 *
 	 * @return \Cake\Http\ServerRequest
 	 */
-	protected function request(string $path, string $method = 'GET'): ServerRequest {
+	protected function request(string $path, string $method = 'GET', ?string $host = null, bool $https = false): ServerRequest {
+		$environment = ['REQUEST_METHOD' => $method];
+		if ($host !== null) {
+			$environment['HTTP_HOST'] = $host;
+		}
+		if ($https) {
+			$environment['HTTPS'] = 'on';
+		}
+
 		return new ServerRequest([
 			'url' => $path,
-			'environment' => ['REQUEST_METHOD' => $method],
+			'environment' => $environment,
 		]);
 	}
 


### PR DESCRIPTION
## Resolve root-relative security.txt URI fields to absolute URLs

`SecurityTxtMiddleware` now resolves root-relative URI field values (e.g. `Contact: /security`, `Canonical: /.well-known/security.txt`) to absolute URLs at serve time, using the request's scheme and host.

### Why

RFC 9116 requires `Canonical` to be an absolute URI and web `Contact` URIs to be `https://`. Previously consumers had to hardcode the full host per deploy (or wire an env var) just to stay compliant. With this change the configured value can stay host-agnostic and travel across environments unchanged, while the served file remains compliant.

### Behavior

* Root-relative values (`/path`) are prefixed with `scheme://authority` from the current request.
* Already-absolute values (`https:`, `mailto:`, `tel:`) and protocol-relative values (`//host/...`) pass through untouched.
* `Expires` and `Preferred-Languages` are never URIs and are skipped.
* The resolved scheme follows the request (so a plain-HTTP local host yields `http://...`); production HTTPS yields `https://...`.

Note: the resolved host comes from the request, so deployments that need to defend against Host-header spoofing on this endpoint should keep using absolute configured values or a trusted-host check. The default (localhost or the real host) is used when no override is present.

### Tests

Added coverage for relative-to-absolute resolution (https + http scheme), pass-through of absolute/mailto values, and default-host resolution. Full suite green (phpunit, phpstan level 8, phpcs).
